### PR TITLE
adding package.xml to enable ament builds

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>fast_cdr</name>
+  <version>1.0.1</version>
+  <description>
+    eProsima's implementation of CDR.
+  </description>
+  <maintainer email="william@osrfoundation.org">William Woodall</maintainer>
+  <license>LGPLv3</license>
+
+  <url>https://github.com/eProsima/Fast-CDR</url>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
This is just a suggestion. If you're ok with having this file in your repository then our build tool (`ament`) will find it and build it along with our packages.

If you'd rather not add this file to your repository (which I would understand), then we can close this I'll just post the `package.xml` to a gist.github.com and in the instructions for how to build our stuff on yours we can instruct people to download the file separately from cloning your repositories.

Note that this `package.xml` file contains the version number and description and license, etc.
All of these files are required, but they don't necessarily have to have up-to-date information.
The only things that really matter for building locally with our build tools are the `name` and `*_depends` tags.

I'll be opening similar pull requests against Fast-RTPS and Fast-RPC.