### PR TITLE
fix clang warnings

### DIFF
--- a/src/cpp/exceptions/Exception.cpp
+++ b/src/cpp/exceptions/Exception.cpp
@@ -31,9 +31,9 @@ Exception& Exception::operator=(const Exception &ex)
 }
 
 #if HAVE_CXX0X
-Exception& Exception::operator=(Exception&&)
+Exception& Exception::operator=(Exception&& ex)
 {
-    m_message = std::move(m_message);
+    m_message = std::move(ex.m_message);
     return *this;
 }
 #endif

--- a/test/ResizeTest.cpp
+++ b/test/ResizeTest.cpp
@@ -1291,7 +1291,7 @@ TEST(CDRResizeTests, SequenceOctet)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    uint8_t *octet_seq_value = NULL; size_t octet_seq_len;
+    uint8_t *octet_seq_value = NULL; size_t octet_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -1318,7 +1318,7 @@ TEST(CDRResizeTests, SequenceChar)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    char *char_seq_value = NULL; size_t char_seq_len;
+    char *char_seq_value = NULL; size_t char_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -1345,7 +1345,7 @@ TEST(CDRResizeTests, SequenceUnsignedShort)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    uint16_t *ushort_seq_value = NULL; size_t ushort_seq_len;
+    uint16_t *ushort_seq_value = NULL; size_t ushort_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -1372,7 +1372,7 @@ TEST(CDRResizeTests, SequenceShort)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    int16_t *short_seq_value = NULL; size_t short_seq_len;
+    int16_t *short_seq_value = NULL; size_t short_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -1399,7 +1399,7 @@ TEST(CDRResizeTests, SequenceUnsignedLong)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    uint32_t *ulong_seq_value = NULL; size_t ulong_seq_len;
+    uint32_t *ulong_seq_value = NULL; size_t ulong_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -1426,7 +1426,7 @@ TEST(CDRResizeTests, SequenceLong)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    int32_t *long_seq_value = NULL; size_t long_seq_len;
+    int32_t *long_seq_value = NULL; size_t long_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -1453,7 +1453,7 @@ TEST(CDRResizeTests, SequenceUnsignedLongLong)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    uint64_t *ulonglong_seq_value = NULL; size_t ulonglong_seq_len;
+    uint64_t *ulonglong_seq_value = NULL; size_t ulonglong_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -1480,7 +1480,7 @@ TEST(CDRResizeTests, SequenceLongLong)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    int64_t *longlong_seq_value = NULL; size_t longlong_seq_len;
+    int64_t *longlong_seq_value = NULL; size_t longlong_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -1507,7 +1507,7 @@ TEST(CDRResizeTests, SequenceFloat)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    float *float_seq_value = NULL; size_t float_seq_len;
+    float *float_seq_value = NULL; size_t float_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -1534,7 +1534,7 @@ TEST(CDRResizeTests, SequenceDouble)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    double *double_seq_value = NULL; size_t double_seq_len;
+    double *double_seq_value = NULL; size_t double_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -1561,7 +1561,7 @@ TEST(CDRResizeTests, SequenceBoolean)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    bool *bool_seq_value = NULL; size_t bool_seq_len;
+    bool *bool_seq_value = NULL; size_t bool_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -1588,7 +1588,7 @@ TEST(CDRResizeTests, SequenceString)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    std::string *string_seq_value = NULL; size_t string_seq_len;
+    std::string *string_seq_value = NULL; size_t string_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -3001,7 +3001,7 @@ TEST(FastCDRResizeTests, SequenceOctet)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    uint8_t *octet_seq_value = NULL; size_t octet_seq_len;
+    uint8_t *octet_seq_value = NULL; size_t octet_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -3028,7 +3028,7 @@ TEST(FastCDRResizeTests, SequenceChar)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    char *char_seq_value = NULL; size_t char_seq_len;
+    char *char_seq_value = NULL; size_t char_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -3055,7 +3055,7 @@ TEST(FastCDRResizeTests, SequenceUnsignedShort)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    uint16_t *ushort_seq_value = NULL; size_t ushort_seq_len;
+    uint16_t *ushort_seq_value = NULL; size_t ushort_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -3082,7 +3082,7 @@ TEST(FastCDRResizeTests, SequenceShort)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    int16_t *short_seq_value = NULL; size_t short_seq_len;
+    int16_t *short_seq_value = NULL; size_t short_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -3109,7 +3109,7 @@ TEST(FastCDRResizeTests, SequenceUnsignedLong)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    uint32_t *ulong_seq_value = NULL; size_t ulong_seq_len;
+    uint32_t *ulong_seq_value = NULL; size_t ulong_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -3136,7 +3136,7 @@ TEST(FastCDRResizeTests, SequenceLong)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    int32_t *long_seq_value = NULL; size_t long_seq_len;
+    int32_t *long_seq_value = NULL; size_t long_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -3163,7 +3163,7 @@ TEST(FastCDRResizeTests, SequenceUnsignedLongLong)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    uint64_t *ulonglong_seq_value = NULL; size_t ulonglong_seq_len;
+    uint64_t *ulonglong_seq_value = NULL; size_t ulonglong_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -3190,7 +3190,7 @@ TEST(FastCDRResizeTests, SequenceLongLong)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    int64_t *longlong_seq_value = NULL; size_t longlong_seq_len;
+    int64_t *longlong_seq_value = NULL; size_t longlong_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -3217,7 +3217,7 @@ TEST(FastCDRResizeTests, SequenceFloat)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    float *float_seq_value = NULL; size_t float_seq_len;
+    float *float_seq_value = NULL; size_t float_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -3244,7 +3244,7 @@ TEST(FastCDRResizeTests, SequenceDouble)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    double *double_seq_value = NULL; size_t double_seq_len;
+    double *double_seq_value = NULL; size_t double_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -3271,7 +3271,7 @@ TEST(FastCDRResizeTests, SequenceBoolean)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    bool *bool_seq_value = NULL; size_t bool_seq_len;
+    bool *bool_seq_value = NULL; size_t bool_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -3298,7 +3298,7 @@ TEST(FastCDRResizeTests, SequenceString)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    std::string *string_seq_value = NULL; size_t string_seq_len;
+    std::string *string_seq_value = NULL; size_t string_seq_len = 0;
 
     EXPECT_NO_THROW(
     {

--- a/test/SimpleTest.cpp
+++ b/test/SimpleTest.cpp
@@ -2505,7 +2505,7 @@ TEST(CDRTests, SequenceOctet)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    uint8_t *octet_seq_value = NULL; size_t octet_seq_len;
+    uint8_t *octet_seq_value = NULL; size_t octet_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -2557,7 +2557,7 @@ TEST(CDRTests, SequenceChar)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    char *char_seq_value = NULL; size_t char_seq_len;
+    char *char_seq_value = NULL; size_t char_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -2609,7 +2609,7 @@ TEST(CDRTests, SequenceUnsignedShort)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    uint16_t *ushort_seq_value = NULL; size_t ushort_seq_len;
+    uint16_t *ushort_seq_value = NULL; size_t ushort_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -2661,7 +2661,7 @@ TEST(CDRTests, SequenceShort)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    int16_t *short_seq_value = NULL; size_t short_seq_len;
+    int16_t *short_seq_value = NULL; size_t short_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -2713,7 +2713,7 @@ TEST(CDRTests, SequenceUnsignedLong)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    uint32_t *ulong_seq_value = NULL; size_t ulong_seq_len;
+    uint32_t *ulong_seq_value = NULL; size_t ulong_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -2765,7 +2765,7 @@ TEST(CDRTests, SequenceLong)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    int32_t *long_seq_value = NULL; size_t long_seq_len;
+    int32_t *long_seq_value = NULL; size_t long_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -2817,7 +2817,7 @@ TEST(CDRTests, SequenceUnsignedLongLong)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    uint64_t *ulonglong_seq_value = NULL; size_t ulonglong_seq_len;
+    uint64_t *ulonglong_seq_value = NULL; size_t ulonglong_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -2869,7 +2869,7 @@ TEST(CDRTests, SequenceLongLong)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    int64_t *longlong_seq_value = NULL; size_t longlong_seq_len;
+    int64_t *longlong_seq_value = NULL; size_t longlong_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -2921,7 +2921,7 @@ TEST(CDRTests, SequenceFloat)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    float *float_seq_value = NULL; size_t float_seq_len;
+    float *float_seq_value = NULL; size_t float_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -2973,7 +2973,7 @@ TEST(CDRTests, SequenceDouble)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    double *double_seq_value = NULL; size_t double_seq_len;
+    double *double_seq_value = NULL; size_t double_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -3025,7 +3025,7 @@ TEST(CDRTests, SequenceBoolean)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    bool *bool_seq_value = NULL; size_t bool_seq_len;
+    bool *bool_seq_value = NULL; size_t bool_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -3077,7 +3077,7 @@ TEST(CDRTests, SequenceString)
     // Deseriazliation.
     Cdr cdr_des(cdrbuffer);
 
-    std::string *string_seq_value = NULL; size_t string_seq_len;
+    std::string *string_seq_value = NULL; size_t string_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -5751,7 +5751,7 @@ TEST(FastCDRTests, SequenceOctet)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    uint8_t *octet_seq_value = NULL; size_t octet_seq_len;
+    uint8_t *octet_seq_value = NULL; size_t octet_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -5803,7 +5803,7 @@ TEST(FastCDRTests, SequenceChar)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    char *char_seq_value = NULL; size_t char_seq_len;
+    char *char_seq_value = NULL; size_t char_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -5855,7 +5855,7 @@ TEST(FastCDRTests, SequenceUnsignedShort)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    uint16_t *ushort_seq_value = NULL; size_t ushort_seq_len;
+    uint16_t *ushort_seq_value = NULL; size_t ushort_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -5907,7 +5907,7 @@ TEST(FastCDRTests, SequenceShort)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    int16_t *short_seq_value = NULL; size_t short_seq_len;
+    int16_t *short_seq_value = NULL; size_t short_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -5959,7 +5959,7 @@ TEST(FastCDRTests, SequenceUnsignedLong)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    uint32_t *ulong_seq_value = NULL; size_t ulong_seq_len;
+    uint32_t *ulong_seq_value = NULL; size_t ulong_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -6011,7 +6011,7 @@ TEST(FastCDRTests, SequenceLong)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    int32_t *long_seq_value = NULL; size_t long_seq_len;
+    int32_t *long_seq_value = NULL; size_t long_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -6063,7 +6063,7 @@ TEST(FastCDRTests, SequenceUnsignedLongLong)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    uint64_t *ulonglong_seq_value = NULL; size_t ulonglong_seq_len;
+    uint64_t *ulonglong_seq_value = NULL; size_t ulonglong_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -6115,7 +6115,7 @@ TEST(FastCDRTests, SequenceLongLong)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    int64_t *longlong_seq_value = NULL; size_t longlong_seq_len;
+    int64_t *longlong_seq_value = NULL; size_t longlong_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -6167,7 +6167,7 @@ TEST(FastCDRTests, SequenceFloat)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    float *float_seq_value = NULL; size_t float_seq_len;
+    float *float_seq_value = NULL; size_t float_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -6219,7 +6219,7 @@ TEST(FastCDRTests, SequenceDouble)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    double *double_seq_value = NULL; size_t double_seq_len;
+    double *double_seq_value = NULL; size_t double_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -6271,7 +6271,7 @@ TEST(FastCDRTests, SequenceBoolean)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    bool *bool_seq_value = NULL; size_t bool_seq_len;
+    bool *bool_seq_value = NULL; size_t bool_seq_len = 0;
 
     EXPECT_NO_THROW(
     {
@@ -6323,7 +6323,7 @@ TEST(FastCDRTests, SequenceString)
     // Deseriazliation.
     FastCdr cdr_des(cdrbuffer);
 
-    std::string *string_seq_value = NULL; size_t string_seq_len;
+    std::string *string_seq_value = NULL; size_t string_seq_len = 0;
 
     EXPECT_NO_THROW(
     {


### PR DESCRIPTION
One warning is actually a bug in the Exception move operator.
The others are uninitialized values.

Warning: before: http://ci.ros2.org/job/ci_osx/626/
Warning after: http://ci.ros2.org/job/ci_osx/628/