### PR TITLE
Control shared/static linking via EPROSIMA_HONOR_BUILD_SHARED_LIBS and BUILD_SHARED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,7 @@ add_subdirectory(src/cpp)
 ###############################################################################
 # Testing
 ###############################################################################
-if(NOT EPROSIMA_INSTALLER)
+if(EPROSIMA_BUILD_TESTS AND NOT EPROSIMA_INSTALLER)
     include(${PROJECT_SOURCE_DIR}/cmake/dev/gtest.cmake)
     check_gtest()
     if(GTEST_FOUND)

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -76,7 +76,11 @@ if(MSVC OR MSVC_IDE)
     endif()
 else()
     #Create library
-    add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_SOURCES})
+    if(EPROSIMA_HONOR_BUILD_SHARED_LIBS)
+      add_library(${PROJECT_NAME} ${${PROJECT_NAME}_SOURCES})
+    else()
+      add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_SOURCES})
+    endif()
 
     # Define public headers
     target_include_directories(${PROJECT_NAME} PUBLIC


### PR DESCRIPTION
This PR allows users to let CMake decide whether to build shared or static libraries via, enable `EPROSIMA_HONOR_BUILD_SHARED_LIBS` and then use `BUILD_SHARED_LIBS`  to control CMake's behavior.

Update:

Connects to https://github.com/ros2/ros2/issues/306