### PR TITLE
Indicate ABI compatibility with soversion

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -77,6 +77,8 @@ if(MSVC OR MSVC_IDE)
 else()
     #Create library
     add_library(${PROJECT_NAME} ${${PROJECT_NAME}_SOURCES})
+    set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION})
+    set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION ${PROJECT_MAJOR_VERSION})
 
     # Define public headers
     target_include_directories(${PROJECT_NAME} PUBLIC


### PR DESCRIPTION
The currently built binary for *nix systems doesn't indicate
its ABI version. This causes QA checks in some build systems
(e.g. OpenEmbedded) report an issue.

This patch adds soversion to the library.