### PR TITLE
use windows.h not afxres.h

### DIFF
--- a/src/cpp/FastCdr.rc
+++ b/src/cpp/FastCdr.rc
@@ -30,7 +30,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "windows.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS


### PR DESCRIPTION
If you don't have Microsoft Foundation Classes for C++ install then you get an error like this:

```
  C:\Program Files (x86)\Windows Kits\8.1\bin\x86\rc.exe /D WIN32 /D _WINDOWS /D NDEBUG /D FASTCDR_DYN_LINK /D FASTCDR_SOURCE /D "CMAKE_INTDIR=\\\"Release\\
  \"" /D fastcdr_EXPORTS /l"0x0409" /I"C:\dev\ros2\src\eProsima\Fast-CDR\include" /IC:\dev\ros2\build\fastcdr\include\fastcdr /nologo /fo"fastcdr.dir\Releas
  e\FastCdr.res" C:\dev\ros2\src\eProsima\Fast-CDR\src\cpp\FastCdr.rc
C:\dev\ros2\src\eProsima\Fast-CDR\src\cpp\FastCdr.rc(33): fatal error RC1015: cannot open include file 'afxres.h'. [C:\dev\ros2\build\fastcdr\src\cpp\fastcdr.vcxproj]
```

According to this SO post, this can safely be replaced with `#include "windows.h"`:

http://stackoverflow.com/questions/3566018/cannot-open-include-file-afxres-h-in-vc2010-express

This does fix the problem on my machine.