### PR TITLE
reserve function to reserve initial space for raw buffer

### DIFF
--- a/include/fastcdr/FastBuffer.h
+++ b/include/fastcdr/FastBuffer.h
@@ -246,6 +246,13 @@ namespace eprosima
                     }
 
                 /*!
+                 * @brief This function reserves memory for the internal raw buffer. It will only do so if the buffer is not yet allocated and is not externally set.
+                 * @param size The size of the memory to be allocated.
+                 * @return True if the allocation suceeded. False if the raw buffer was set externally or is already allocated.
+                 */
+                bool reserve(size_t size);
+
+                /*!
                  * @brief This function resizes the raw buffer. It will call the user's defined function for this purpose.
                  * @param minSizeInc The minimun growth expected of the current raw buffer.
                  * @return True if the operation works. False if it does not.

--- a/src/cpp/FastBuffer.cpp
+++ b/src/cpp/FastBuffer.cpp
@@ -42,6 +42,19 @@ FastBuffer::~FastBuffer()
     }
 }
 
+bool FastBuffer::reserve(size_t size)
+{
+    if (m_internalBuffer && m_buffer == NULL)
+    {
+        m_buffer = (char *)malloc(size);
+        if (m_buffer) {
+          m_bufferSize = size;
+          return true;
+        }
+    }
+    return false;
+}
+
 bool FastBuffer::resize(size_t minSizeInc)
 {
     size_t incBufferSize = BUFFER_START_LENGTH;

--- a/test/ResizeTest.cpp
+++ b/test/ResizeTest.cpp
@@ -3820,3 +3820,21 @@ TEST(FastCDRResizeTests, Complete)
     free(ldouble_seq_value);
     free(c_string_value);
 }
+
+TEST(CDRResizeTests, ReserveBuffer)
+{
+    FastBuffer buffer0;
+    EXPECT_EQ(true, buffer0.reserve(100));
+    EXPECT_EQ(100, buffer0.getBufferSize());
+
+    FastBuffer buffer1;
+    EXPECT_EQ(true, buffer1.resize(100));
+    EXPECT_EQ(200, buffer1.getBufferSize());
+    EXPECT_EQ(false, buffer1.reserve(300));
+    EXPECT_EQ(200, buffer1.getBufferSize());
+
+    char raw_buffer[10];
+    FastBuffer buffer2(&raw_buffer[0], 10);
+    EXPECT_EQ(false, buffer2.reserve(100));
+    EXPECT_EQ(10, buffer2.getBufferSize());
+}


### PR DESCRIPTION
Connects to https://github.com/eProsima/Fast-CDR/issues/15

As I suppose that resizing to 200 has a special meaning, this PR adds a `reserve` function which lets you pre-initialize the internal memory to a value less than 200. 
It only allows so if the internal memory was not set externally in the constructor as well as was not pre-initialized before (i.e. `m_Buffer == NULL`)