### PR TITLE
deserialize´s method with error. (long double, BIG_ENDIANNESS)

### DIFF
--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -93,7 +93,7 @@ namespace eprosima
                     /*!
                      * @brief Default constructor.
                      */
-                    state(const Cdr &cdr);
+                    explicit state(const Cdr &cdr);
 
                     /*!
                      * @brief Copy constructor.

--- a/include/fastcdr/FastCdr.h
+++ b/include/fastcdr/FastCdr.h
@@ -56,7 +56,7 @@ namespace eprosima
                     /*!
                      * @brief Default constructor.
                      */
-                    state(const FastCdr &fastcdr);
+                    explicit state(const FastCdr &fastcdr);
 
                     /*!
                      * @brief Copy constructor.
@@ -76,7 +76,7 @@ namespace eprosima
                  *
                  * @param cdrBuffer A reference to the buffer that contains (or will contain) the CDR representation.
                  */
-                FastCdr(FastBuffer &cdrBuffer);
+                explicit FastCdr(FastBuffer &cdrBuffer);
 
                 /*!
                  * @brief This function skips a number of bytes in the CDR stream buffer.

--- a/include/fastcdr/exceptions/BadParamException.h
+++ b/include/fastcdr/exceptions/BadParamException.h
@@ -36,7 +36,7 @@ namespace eprosima
                      *
                      * @param message A error message. This message is copied.
                      */
-                    Cdr_DllAPI BadParamException(const char* const &message);
+                    explicit Cdr_DllAPI BadParamException(const char* const &message);
 
                     /*!
                      * @brief Default copy constructor.
@@ -74,7 +74,7 @@ namespace eprosima
                     virtual Cdr_DllAPI ~BadParamException() throw();
 
                     //! @brief This function throws the object as exception.
-                    virtual Cdr_DllAPI void raise() const;
+                    Cdr_DllAPI void raise() const override;
 
                     //! @brief Default message used in the library.
                     static Cdr_DllAPI const char* const BAD_PARAM_MESSAGE_DEFAULT;

--- a/include/fastcdr/exceptions/Exception.h
+++ b/include/fastcdr/exceptions/Exception.h
@@ -53,7 +53,7 @@ namespace eprosima
                      *
                      * @param message A error message. This message is copied.
                      */
-                    Cdr_DllAPI Exception(const char* const &message);
+                    explicit Cdr_DllAPI Exception(const char* const &message);
 
                     /*!
                      * @brief Default copy constructor.

--- a/include/fastcdr/exceptions/NotEnoughMemoryException.h
+++ b/include/fastcdr/exceptions/NotEnoughMemoryException.h
@@ -36,7 +36,7 @@ namespace eprosima
                      *
                      * @param message A error message. This message is copied.
                      */
-                    Cdr_DllAPI NotEnoughMemoryException(const char* const &message);
+                    explicit Cdr_DllAPI NotEnoughMemoryException(const char* const &message);
 
                     /*!
                      * @brief Default copy constructor.
@@ -74,7 +74,7 @@ namespace eprosima
                     virtual Cdr_DllAPI ~NotEnoughMemoryException() throw();
 
                     //! @brief This function throws the object as exception.
-                    virtual Cdr_DllAPI void raise() const;
+                    Cdr_DllAPI void raise() const override;
 
                     //! @brief Default message used in the library.
                     static Cdr_DllAPI const char* const NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT;

--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -1438,6 +1438,15 @@ Cdr& Cdr::deserialize(long double &ldouble_t)
         {
             char *dst = reinterpret_cast<char*>(&ldouble_t);
 
+            m_currentPosition++ >> dst[15];
+            m_currentPosition++ >> dst[14];
+            m_currentPosition++ >> dst[13];
+            m_currentPosition++ >> dst[12];
+            m_currentPosition++ >> dst[11];
+            m_currentPosition++ >> dst[10];
+            m_currentPosition++ >> dst[9];
+            m_currentPosition++ >> dst[8];
+
             m_currentPosition++ >> dst[7];
             m_currentPosition++ >> dst[6];
             m_currentPosition++ >> dst[5];

--- a/src/cpp/FastBuffer.cpp
+++ b/src/cpp/FastBuffer.cpp
@@ -79,31 +79,17 @@ bool FastBuffer::resize(size_t minSizeInc)
         }
         else
         {
-            m_bufferSize += incBufferSize;
-
-            /*
-            Summary: Common realloc mistake: 'm_buffer' nulled but not freed upon failure
-            Message: Common realloc mistake: 'm_buffer' nulled but not freed upon failure
-             */
-
-            void *p = realloc(m_buffer, m_bufferSize);
-            /*
-            more info: http://www.cplusplus.com/reference/cstdlib/realloc/
-            If the function fails to allocate the requested block of memory, a null pointer is returned,
-            and the memory block pointed to by argument ptr is not deallocated
-            (it is still valid, and with its contents unchanged).
-             */
-
-            if (p) {
+            size_t newBufferSize = m_bufferSize + incBufferSize;
+            void *p = realloc(m_buffer, newBufferSize);
+            if (p)
+            {
                m_buffer = reinterpret_cast<char*>(p);
 
                if (m_buffer != NULL) {
+                  m_bufferSize = newBufferSize;
+
                   return true;
                }
-            }
-            else {
-               free(m_buffer);
-               m_bufferSize = 0;
             }
         }
     }

--- a/src/cpp/FastBuffer.cpp
+++ b/src/cpp/FastBuffer.cpp
@@ -84,12 +84,8 @@ bool FastBuffer::resize(size_t minSizeInc)
             if (p)
             {
                m_buffer = reinterpret_cast<char*>(p);
-
-               if (m_buffer != NULL) {
-                  m_bufferSize = newBufferSize;
-
-                  return true;
-               }
+               m_bufferSize = newBufferSize;
+               return true;
             }
         }
     }

--- a/src/cpp/FastBuffer.cpp
+++ b/src/cpp/FastBuffer.cpp
@@ -81,11 +81,29 @@ bool FastBuffer::resize(size_t minSizeInc)
         {
             m_bufferSize += incBufferSize;
 
-            m_buffer = reinterpret_cast<char*>(realloc(m_buffer, m_bufferSize));
+            /*
+            Summary: Common realloc mistake: 'm_buffer' nulled but not freed upon failure
+            Message: Common realloc mistake: 'm_buffer' nulled but not freed upon failure
+             */
 
-            if(m_buffer != NULL)
-            {
-                return true;
+            void *p = realloc(m_buffer, m_bufferSize);
+            /*
+            more info: http://www.cplusplus.com/reference/cstdlib/realloc/
+            If the function fails to allocate the requested block of memory, a null pointer is returned,
+            and the memory block pointed to by argument ptr is not deallocated
+            (it is still valid, and with its contents unchanged).
+             */
+
+            if (p) {
+               m_buffer = reinterpret_cast<char*>(p);
+
+               if (m_buffer != NULL) {
+                  return true;
+               }
+            }
+            else {
+               free(m_buffer);
+               m_bufferSize = 0;
             }
         }
     }


### PR DESCRIPTION
m_currentPosition++ >> dst[15];
m_currentPosition++ >> dst[14];
m_currentPosition++ >> dst[13];
m_currentPosition++ >> dst[12];
m_currentPosition++ >> dst[11];
m_currentPosition++ >> dst[10];
m_currentPosition++ >> dst[9];
m_currentPosition++ >> dst[8];


bugfix: #25 

Please edits / comments want you want
@MiguelCompany 
@JaimeMartin 
