### PR TITLE
Add LIB_SUFFIX support to Cmake build files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ endif()
 ###############################################################################
 set(BIN_INSTALL_DIR bin/ CACHE PATH "Installation directory for binaries")
 set(INCLUDE_INSTALL_DIR include/ CACHE PATH "Installation directory for C++ headers")
-set(LIB_INSTALL_DIR lib/ CACHE PATH "Installation directory for libraries")
+set(LIB_INSTALL_DIR lib${LIB_SUFFIX}/ CACHE PATH "Installation directory for libraries")
 set(DATA_INSTALL_DIR share/ CACHE PATH "Installation directory for data")
 if(WIN32 AND EPROSIMA_INSTALLER AND IS_TOP_LEVEL)
     set(LICENSE_INSTALL_DIR . CACHE PATH "Installation directory for licenses")


### PR DESCRIPTION
Set installation directory correctly for libraries on systems that use LIB_SUFFIX. (This includes the build system on Gentoo.)