### PR TITLE
Fix warnings and tests for 32-bit ARM

### DIFF
--- a/include/fastcdr/FastBuffer.h
+++ b/include/fastcdr/FastBuffer.h
@@ -22,11 +22,13 @@
 #include <cstddef>
 #include <utility>
 
-#if defined(FASTCDR_32BIT)
-#define SIZE_TO_32BIT(x) x
-#else
-#define SIZE_TO_32BIT(x) static_cast<uint32_t>(x)
-#endif
+inline uint32_t size_to_uint32(size_t val) {
+  #if defined(FASTCDR_32BIT)
+  return val;
+  #else
+  return static_cast<uint32_t>(val);
+  #endif
+}
 
 namespace eprosima
 {

--- a/include/fastcdr/FastBuffer.h
+++ b/include/fastcdr/FastBuffer.h
@@ -23,7 +23,7 @@
 #include <utility>
 
 inline uint32_t size_to_uint32(size_t val) {
-  #if defined(_WIN32) || !defined(FASTCDR_32BIT)
+  #if defined(_WIN32) or not defined(FASTCDR_ARM32)
   // On 64 bit platforms and all Windows architectures (because of C4267), explicitly cast.
   return static_cast<uint32_t>(val);
   #else

--- a/include/fastcdr/FastBuffer.h
+++ b/include/fastcdr/FastBuffer.h
@@ -82,7 +82,11 @@ namespace eprosima
                     inline
                     void operator<<(const _T &data)
                     {
+                        #if defined(FASTCDR_32BIT)
+                        memcpy(m_currentPosition, &data, sizeof(_T));
+                        #else
                         *(reinterpret_cast<_T*>(m_currentPosition)) = data;
+                        #endif
                     }
 
                 /*!
@@ -94,7 +98,13 @@ namespace eprosima
                     inline
                     void operator>>(_T &data)
                     {
+                        #if defined(FASTCDR_32BIT)
+                        _T val;
+                        memcpy(&val, m_currentPosition, sizeof(_T));
+                        data = val;
+                        #else
                         data = *(reinterpret_cast<_T*>(m_currentPosition));
+                        #endif
                     }
 
                 /*!
@@ -167,7 +177,7 @@ namespace eprosima
                  * @brief This function returns the current position in the raw buffer.
                  * @return The current position in the raw buffer.
                  */
-                inline 
+                inline
                     char* operator&()
                     {
                         return m_currentPosition;

--- a/include/fastcdr/FastBuffer.h
+++ b/include/fastcdr/FastBuffer.h
@@ -23,10 +23,12 @@
 #include <utility>
 
 inline uint32_t size_to_uint32(size_t val) {
-  #if defined(FASTCDR_32BIT)
-  return val;
-  #else
+  #if defined(_WIN32) || !defined(FASTCDR_32BIT)
+  // On 64 bit platforms and all Windows architectures (because of C4267), explicitly cast.
   return static_cast<uint32_t>(val);
+  #else
+  // Skip useless cast on 32-bit builds.
+  return val;
   #endif
 }
 

--- a/include/fastcdr/FastBuffer.h
+++ b/include/fastcdr/FastBuffer.h
@@ -22,6 +22,12 @@
 #include <cstddef>
 #include <utility>
 
+#if defined(FASTCDR_32BIT)
+#define SIZE_TO_32BIT(x) x
+#else
+#define SIZE_TO_32BIT(x) static_cast<uint32_t>(x)
+#endif
+
 namespace eprosima
 {
     namespace fastcdr

--- a/include/fastcdr/FastBuffer.h
+++ b/include/fastcdr/FastBuffer.h
@@ -92,7 +92,7 @@ namespace eprosima
                     inline
                     void operator<<(const _T &data)
                     {
-                        #if defined(FASTCDR_32BIT)
+                        #if defined(FASTCDR_ARM32)
                         memcpy(m_currentPosition, &data, sizeof(_T));
                         #else
                         *(reinterpret_cast<_T*>(m_currentPosition)) = data;
@@ -108,7 +108,7 @@ namespace eprosima
                     inline
                     void operator>>(_T &data)
                     {
-                        #if defined(FASTCDR_32BIT)
+                        #if defined(FASTCDR_ARM32)
                         _T val;
                         memcpy(&val, m_currentPosition, sizeof(_T));
                         data = val;

--- a/include/fastcdr/FastBuffer.h
+++ b/include/fastcdr/FastBuffer.h
@@ -23,7 +23,7 @@
 #include <utility>
 
 inline uint32_t size_to_uint32(size_t val) {
-  #if defined(_WIN32) or not defined(FASTCDR_ARM32)
+  #if defined(_WIN32) || !defined(FASTCDR_ARM32)
   // On 64 bit platforms and all Windows architectures (because of C4267), explicitly cast.
   return static_cast<uint32_t>(val);
   #else

--- a/include/fastcdr/FastCdr.h
+++ b/include/fastcdr/FastCdr.h
@@ -666,7 +666,7 @@ namespace eprosima
                         if(((m_lastPosition - m_currentPosition) >= sizeof(ldouble_t)) || resize(sizeof(ldouble_t)))
                         {
                             m_currentPosition << ldouble_t;
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32)
                             m_currentPosition += sizeof(ldouble_t);
                             m_currentPosition << static_cast<long double>(0);
 #endif
@@ -1238,7 +1238,7 @@ namespace eprosima
                         {
                             m_currentPosition >> ldouble_t;
                             m_currentPosition += sizeof(ldouble_t);
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32)
                             m_currentPosition += sizeof(ldouble_t);
 #endif
 

--- a/include/fastcdr/FastCdr.h
+++ b/include/fastcdr/FastCdr.h
@@ -666,7 +666,7 @@ namespace eprosima
                         if(((m_lastPosition - m_currentPosition) >= sizeof(ldouble_t)) || resize(sizeof(ldouble_t)))
                         {
                             m_currentPosition << ldouble_t;
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
                             m_currentPosition += sizeof(ldouble_t);
                             m_currentPosition << static_cast<long double>(0);
 #endif
@@ -1238,7 +1238,7 @@ namespace eprosima
                         {
                             m_currentPosition >> ldouble_t;
                             m_currentPosition += sizeof(ldouble_t);
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
                             m_currentPosition += sizeof(ldouble_t);
 #endif
 

--- a/include/fastcdr/config.h.in
+++ b/include/fastcdr/config.h.in
@@ -46,4 +46,12 @@
 #define __BIG_ENDIAN__ @__BIG_ENDIAN__@
 #endif
 
+#if defined(__ARM_ARCH) && __ARM_ARCH <= 7
+#define FASTCDR_32BIT
+#endif
+
+#if defined(_WIN32)
+#define FASTCDR_32BIT
+#endif
+
 #endif // _FASTCDR_CONFIG_H_

--- a/include/fastcdr/config.h.in
+++ b/include/fastcdr/config.h.in
@@ -50,7 +50,7 @@
 #define FASTCDR_32BIT
 #endif
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(_WIN64)
 #define FASTCDR_32BIT
 #endif
 

--- a/include/fastcdr/config.h.in
+++ b/include/fastcdr/config.h.in
@@ -47,6 +47,7 @@
 #endif
 
 #if defined(__ARM_ARCH) && __ARM_ARCH <= 7
+#define FASTCDR_ARM32
 #define FASTCDR_32BIT
 #endif
 

--- a/include/fastcdr/config.h.in
+++ b/include/fastcdr/config.h.in
@@ -48,11 +48,6 @@
 
 #if defined(__ARM_ARCH) && __ARM_ARCH <= 7
 #define FASTCDR_ARM32
-#define FASTCDR_32BIT
-#endif
-
-#if defined(_WIN32) && !defined(_WIN64)
-#define FASTCDR_32BIT
 #endif
 
 #endif // _FASTCDR_CONFIG_H_

--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -541,7 +541,7 @@ Cdr& Cdr::serialize(const long double ldouble_t)
         if(m_swapBytes)
         {
             const char *dst = reinterpret_cast<const char*>(&ldouble_t);
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32) or defined(FASTCDR_ARM32)
             // Filled with 0's.
             m_currentPosition++ << static_cast<char>(0);
             m_currentPosition++ << static_cast<char>(0);
@@ -581,7 +581,7 @@ Cdr& Cdr::serialize(const long double ldouble_t)
         }
         else
         {
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32) or defined(FASTCDR_ARM32)
             m_currentPosition << static_cast<long double>(0);
             m_currentPosition += sizeof(ldouble_t);
 #endif
@@ -690,7 +690,8 @@ Cdr& Cdr::serialize(const wchar_t *string_t)
             // Save last datasize.
             m_lastDataSize = sizeof(uint32_t);
 
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32)
+// #if defined(FASTCDR_32BIT)
             serializeArray(string_t, wstrlen);
 #else
             m_currentPosition.memcopy(string_t, bytesLength);
@@ -1173,7 +1174,7 @@ Cdr& Cdr::serializeArray(const long double *ldouble_t, size_t numElements)
 
             for(; dst < end; dst += sizeof(*ldouble_t))
             {
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32) or defined(FASTCDR_ARM32)
                 // Filled with 0's.
                 m_currentPosition++ << static_cast<char>(0);
                 m_currentPosition++ << static_cast<char>(0);

--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -541,7 +541,7 @@ Cdr& Cdr::serialize(const long double ldouble_t)
         if(m_swapBytes)
         {
             const char *dst = reinterpret_cast<const char*>(&ldouble_t);
-#if defined(_WIN32) or defined(FASTCDR_ARM32)
+#if defined(_WIN32) || defined(FASTCDR_ARM32)
             // Filled with 0's.
             m_currentPosition++ << static_cast<char>(0);
             m_currentPosition++ << static_cast<char>(0);
@@ -581,7 +581,7 @@ Cdr& Cdr::serialize(const long double ldouble_t)
         }
         else
         {
-#if defined(_WIN32) or defined(FASTCDR_ARM32)
+#if defined(_WIN32) || defined(FASTCDR_ARM32)
             m_currentPosition << static_cast<long double>(0);
             m_currentPosition += sizeof(ldouble_t);
 #endif
@@ -1173,7 +1173,7 @@ Cdr& Cdr::serializeArray(const long double *ldouble_t, size_t numElements)
 
             for(; dst < end; dst += sizeof(*ldouble_t))
             {
-#if defined(_WIN32) or defined(FASTCDR_ARM32)
+#if defined(_WIN32) || defined(FASTCDR_ARM32)
                 // Filled with 0's.
                 m_currentPosition++ << static_cast<char>(0);
                 m_currentPosition++ << static_cast<char>(0);
@@ -1213,7 +1213,7 @@ Cdr& Cdr::serializeArray(const long double *ldouble_t, size_t numElements)
         }
         else
         {
-#if defined(_WIN32) or defined(FASTCDR_ARM32)
+#if defined(_WIN32) || defined(FASTCDR_ARM32)
             for (size_t i = 0; i < numElements; ++i)
             {
                 m_currentPosition << static_cast<long double>(0);
@@ -1554,7 +1554,7 @@ Cdr& Cdr::deserialize(long double &ldouble_t)
         {
             char *dst = reinterpret_cast<char*>(&ldouble_t);
 
-#if defined(_WIN32) or defined(FASTCDR_ARM32)
+#if defined(_WIN32) || defined(FASTCDR_ARM32)
             m_currentPosition += 8;
             m_currentPosition++ >> dst[7];
             m_currentPosition++ >> dst[6];
@@ -1585,7 +1585,7 @@ Cdr& Cdr::deserialize(long double &ldouble_t)
         }
         else
         {
-#if defined(_WIN32) or defined(FASTCDR_ARM32)
+#if defined(_WIN32) || defined(FASTCDR_ARM32)
             // Windows case, just deserializes the last 8 bytes, and ignores the first 8
             m_currentPosition += 8; // sizeof(ldouble_t);
 #endif
@@ -1796,7 +1796,7 @@ const std::wstring Cdr::readWString(uint32_t &length)
         // Save last datasize.
         m_lastDataSize = sizeof(uint32_t);
 
-#if defined(_WIN32) or defined(FASTCDR_ARM32)
+#if defined(_WIN32) || defined(FASTCDR_ARM32)
         wchar_t* wValue = new wchar_t[length];
         deserializeArray(wValue, length);
 #else
@@ -1808,7 +1808,7 @@ const std::wstring Cdr::readWString(uint32_t &length)
             --length;
         }
         returnedValue = std::wstring(wValue, length);
-#if defined(_WIN32) or defined(FASTCDR_ARM32)
+#if defined(_WIN32) || defined(FASTCDR_ARM32)
         delete [] wValue;
 #endif
         return returnedValue;
@@ -2254,7 +2254,7 @@ Cdr& Cdr::deserializeArray(long double *ldouble_t, size_t numElements)
 
             for(; dst < end; dst += sizeof(*ldouble_t))
             {
-#if defined(_WIN32) or defined(FASTCDR_ARM32)
+#if defined(_WIN32) || defined(FASTCDR_ARM32)
                 m_currentPosition += 8;
                 m_currentPosition++ >> dst[7];
                 m_currentPosition++ >> dst[6];
@@ -2286,7 +2286,7 @@ Cdr& Cdr::deserializeArray(long double *ldouble_t, size_t numElements)
         }
         else
         {
-#if defined(_WIN32) or defined(FASTCDR_ARM32)
+#if defined(_WIN32) || defined(FASTCDR_ARM32)
             for (size_t i = 0; i < numElements; ++i)
             {
                 m_currentPosition += 8;   // Ignore first 8 bytes

--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -635,11 +635,11 @@ Cdr& Cdr::serialize(const bool bool_t)
 
 Cdr& Cdr::serialize(const char *string_t)
 {
-    size_t length = 0;
+    uint32_t length = 0;
 
     if(string_t != nullptr)
     {
-        length = strlen(string_t) + 1;
+        length = SIZE_TO_32BIT(strlen(string_t)) + 1;
     }
 
     if(length > 0)
@@ -671,19 +671,19 @@ Cdr& Cdr::serialize(const char *string_t)
 
 Cdr& Cdr::serialize(const wchar_t *string_t)
 {
-    size_t bytesLength = 0;
+    uint32_t bytesLength = 0;
     size_t wstrlen = 0;
 
     if (string_t != nullptr)
     {
         wstrlen = wcslen(string_t);
-        bytesLength = wstrlen * 4;
+        bytesLength = SIZE_TO_32BIT(wstrlen * 4);
     }
 
     if(bytesLength > 0)
     {
         Cdr::state state_(*this);
-        serialize(wstrlen);
+        serialize(SIZE_TO_32BIT(wstrlen));
 
         if(((m_lastPosition - m_currentPosition) >= bytesLength) || resize(bytesLength))
         {

--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -541,7 +541,7 @@ Cdr& Cdr::serialize(const long double ldouble_t)
         if(m_swapBytes)
         {
             const char *dst = reinterpret_cast<const char*>(&ldouble_t);
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
             // Filled with 0's.
             m_currentPosition++ << static_cast<char>(0);
             m_currentPosition++ << static_cast<char>(0);
@@ -581,7 +581,7 @@ Cdr& Cdr::serialize(const long double ldouble_t)
         }
         else
         {
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
             m_currentPosition << static_cast<long double>(0);
             m_currentPosition += sizeof(ldouble_t);
 #endif
@@ -635,10 +635,12 @@ Cdr& Cdr::serialize(const bool bool_t)
 
 Cdr& Cdr::serialize(const char *string_t)
 {
-    uint32_t length = 0;
+    size_t length = 0;
 
     if(string_t != nullptr)
-        length = static_cast<uint32_t>(strlen(string_t)) + 1;
+    {
+        length = strlen(string_t) + 1;
+    }
 
     if(length > 0)
     {
@@ -669,26 +671,26 @@ Cdr& Cdr::serialize(const char *string_t)
 
 Cdr& Cdr::serialize(const wchar_t *string_t)
 {
-    uint32_t bytesLength = 0;
+    size_t bytesLength = 0;
     size_t wstrlen = 0;
 
     if (string_t != nullptr)
     {
         wstrlen = wcslen(string_t);
-        bytesLength = static_cast<uint32_t>(wstrlen * 4);
+        bytesLength = wstrlen * 4;
     }
 
     if(bytesLength > 0)
     {
         Cdr::state state_(*this);
-        serialize(static_cast<uint32_t>(wstrlen));
+        serialize(wstrlen);
 
         if(((m_lastPosition - m_currentPosition) >= bytesLength) || resize(bytesLength))
         {
             // Save last datasize.
             m_lastDataSize = sizeof(uint32_t);
 
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
             serializeArray(string_t, wstrlen);
 #else
             m_currentPosition.memcopy(string_t, bytesLength);
@@ -1171,7 +1173,7 @@ Cdr& Cdr::serializeArray(const long double *ldouble_t, size_t numElements)
 
             for(; dst < end; dst += sizeof(*ldouble_t))
             {
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
                 // Filled with 0's.
                 m_currentPosition++ << static_cast<char>(0);
                 m_currentPosition++ << static_cast<char>(0);
@@ -1211,7 +1213,7 @@ Cdr& Cdr::serializeArray(const long double *ldouble_t, size_t numElements)
         }
         else
         {
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
             for (size_t i = 0; i < numElements; ++i)
             {
                 m_currentPosition << static_cast<long double>(0);
@@ -1552,7 +1554,7 @@ Cdr& Cdr::deserialize(long double &ldouble_t)
         {
             char *dst = reinterpret_cast<char*>(&ldouble_t);
 
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
             m_currentPosition += 8;
             m_currentPosition++ >> dst[7];
             m_currentPosition++ >> dst[6];
@@ -1583,7 +1585,7 @@ Cdr& Cdr::deserialize(long double &ldouble_t)
         }
         else
         {
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
             // Windows case, just deserializes the last 8 bytes, and ignores the first 8
             m_currentPosition += 8; // sizeof(ldouble_t);
 #endif
@@ -1691,7 +1693,7 @@ Cdr& Cdr::deserialize(wchar_t *&string_t)
         // Allocate memory.
         string_t = reinterpret_cast<wchar_t*>(calloc(length + 1, sizeof(wchar_t))); // WStrings never serialize terminating zero
 
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
         for (size_t idx = 0; idx < length; ++idx)
         {
             uint32_t temp;
@@ -1794,7 +1796,7 @@ const std::wstring Cdr::readWString(uint32_t &length)
         // Save last datasize.
         m_lastDataSize = sizeof(uint32_t);
 
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
         wchar_t* wValue = new wchar_t[length];
         deserializeArray(wValue, length);
 #else
@@ -1806,7 +1808,7 @@ const std::wstring Cdr::readWString(uint32_t &length)
             --length;
         }
         returnedValue = std::wstring(wValue, length);
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
         delete [] wValue;
 #endif
         return returnedValue;
@@ -2252,7 +2254,7 @@ Cdr& Cdr::deserializeArray(long double *ldouble_t, size_t numElements)
 
             for(; dst < end; dst += sizeof(*ldouble_t))
             {
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
                 m_currentPosition += 8;
                 m_currentPosition++ >> dst[7];
                 m_currentPosition++ >> dst[6];
@@ -2284,7 +2286,7 @@ Cdr& Cdr::deserializeArray(long double *ldouble_t, size_t numElements)
         }
         else
         {
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
             for (size_t i = 0; i < numElements; ++i)
             {
                 m_currentPosition += 8;   // Ignore first 8 bytes

--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -639,7 +639,7 @@ Cdr& Cdr::serialize(const char *string_t)
 
     if(string_t != nullptr)
     {
-        length = SIZE_TO_32BIT(strlen(string_t)) + 1;
+        length = size_to_uint32(strlen(string_t)) + 1;
     }
 
     if(length > 0)
@@ -677,13 +677,13 @@ Cdr& Cdr::serialize(const wchar_t *string_t)
     if (string_t != nullptr)
     {
         wstrlen = wcslen(string_t);
-        bytesLength = SIZE_TO_32BIT(wstrlen * 4);
+        bytesLength = size_to_uint32(wstrlen * 4);
     }
 
     if(bytesLength > 0)
     {
         Cdr::state state_(*this);
-        serialize(SIZE_TO_32BIT(wstrlen));
+        serialize(size_to_uint32(wstrlen));
 
         if(((m_lastPosition - m_currentPosition) >= bytesLength) || resize(bytesLength))
         {

--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -691,7 +691,6 @@ Cdr& Cdr::serialize(const wchar_t *string_t)
             m_lastDataSize = sizeof(uint32_t);
 
 #if defined(_WIN32)
-// #if defined(FASTCDR_32BIT)
             serializeArray(string_t, wstrlen);
 #else
             m_currentPosition.memcopy(string_t, bytesLength);
@@ -1695,7 +1694,6 @@ Cdr& Cdr::deserialize(wchar_t *&string_t)
         string_t = reinterpret_cast<wchar_t*>(calloc(length + 1, sizeof(wchar_t))); // WStrings never serialize terminating zero
 
 #if defined(_WIN32)
-// #if defined(FASTCDR_32BIT)
         for (size_t idx = 0; idx < length; ++idx)
         {
             uint32_t temp;

--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -1214,7 +1214,7 @@ Cdr& Cdr::serializeArray(const long double *ldouble_t, size_t numElements)
         }
         else
         {
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32) or defined(FASTCDR_ARM32)
             for (size_t i = 0; i < numElements; ++i)
             {
                 m_currentPosition << static_cast<long double>(0);
@@ -1555,7 +1555,7 @@ Cdr& Cdr::deserialize(long double &ldouble_t)
         {
             char *dst = reinterpret_cast<char*>(&ldouble_t);
 
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32) or defined(FASTCDR_ARM32)
             m_currentPosition += 8;
             m_currentPosition++ >> dst[7];
             m_currentPosition++ >> dst[6];
@@ -1586,7 +1586,7 @@ Cdr& Cdr::deserialize(long double &ldouble_t)
         }
         else
         {
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32) or defined(FASTCDR_ARM32)
             // Windows case, just deserializes the last 8 bytes, and ignores the first 8
             m_currentPosition += 8; // sizeof(ldouble_t);
 #endif
@@ -1694,7 +1694,8 @@ Cdr& Cdr::deserialize(wchar_t *&string_t)
         // Allocate memory.
         string_t = reinterpret_cast<wchar_t*>(calloc(length + 1, sizeof(wchar_t))); // WStrings never serialize terminating zero
 
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32)
+// #if defined(FASTCDR_32BIT)
         for (size_t idx = 0; idx < length; ++idx)
         {
             uint32_t temp;
@@ -1797,7 +1798,7 @@ const std::wstring Cdr::readWString(uint32_t &length)
         // Save last datasize.
         m_lastDataSize = sizeof(uint32_t);
 
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32) or defined(FASTCDR_ARM32)
         wchar_t* wValue = new wchar_t[length];
         deserializeArray(wValue, length);
 #else
@@ -1809,7 +1810,7 @@ const std::wstring Cdr::readWString(uint32_t &length)
             --length;
         }
         returnedValue = std::wstring(wValue, length);
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32) or defined(FASTCDR_ARM32)
         delete [] wValue;
 #endif
         return returnedValue;
@@ -2255,7 +2256,7 @@ Cdr& Cdr::deserializeArray(long double *ldouble_t, size_t numElements)
 
             for(; dst < end; dst += sizeof(*ldouble_t))
             {
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32) or defined(FASTCDR_ARM32)
                 m_currentPosition += 8;
                 m_currentPosition++ >> dst[7];
                 m_currentPosition++ >> dst[6];
@@ -2287,7 +2288,7 @@ Cdr& Cdr::deserializeArray(long double *ldouble_t, size_t numElements)
         }
         else
         {
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32) or defined(FASTCDR_ARM32)
             for (size_t i = 0; i < numElements; ++i)
             {
                 m_currentPosition += 8;   // Ignore first 8 bytes

--- a/src/cpp/FastCdr.cpp
+++ b/src/cpp/FastCdr.cpp
@@ -94,7 +94,7 @@ FastCdr& FastCdr::serialize(const char *string_t)
 
     if(string_t != nullptr)
     {
-        length = SIZE_TO_32BIT(strlen(string_t)) + 1;
+        length = size_to_uint32(strlen(string_t)) + 1;
     }
 
     if(length > 0)
@@ -129,13 +129,13 @@ FastCdr& FastCdr::serialize(const wchar_t *string_t)
     if (string_t != nullptr)
     {
         wstrlen = wcslen(string_t);
-        bytesLength = SIZE_TO_32BIT(wstrlen * 4);
+        bytesLength = size_to_uint32(wstrlen * 4);
     }
 
     if(bytesLength > 0)
     {
         FastCdr::state state_(*this);
-        serialize(SIZE_TO_32BIT(wstrlen));
+        serialize(size_to_uint32(wstrlen));
 
         if(((m_lastPosition - m_currentPosition) >= bytesLength) || resize(bytesLength))
         {

--- a/src/cpp/FastCdr.cpp
+++ b/src/cpp/FastCdr.cpp
@@ -139,7 +139,8 @@ FastCdr& FastCdr::serialize(const wchar_t *string_t)
 
         if(((m_lastPosition - m_currentPosition) >= bytesLength) || resize(bytesLength))
         {
-#if defined(FASTCDR_32BIT)
+// #if defined(FASTCDR_32BIT)
+#if defined(_WIN32)
             serializeArray(string_t, wstrlen);
 #else
             m_currentPosition.memcopy(string_t, bytesLength);
@@ -281,7 +282,7 @@ FastCdr& FastCdr::serializeArray(const long double *ldouble_t, size_t numElement
 
     if(((m_lastPosition - m_currentPosition) >= totalSize) || resize(totalSize))
     {
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32) or defined(FASTCDR_ARM32)
         for (size_t idx = 0; idx < numElements; ++idx)
         {
             m_currentPosition << static_cast<long double>(0);
@@ -367,7 +368,8 @@ FastCdr& FastCdr::deserialize(wchar_t *&string_t)
         // Allocate memory.
         string_t = reinterpret_cast<wchar_t*>(calloc(length + 1, sizeof(wchar_t))); // WStrings never serialize terminating zero
 
-#if defined(FASTCDR_32BIT)
+// #if defined(FASTCDR_32BIT)
+#if defined(_WIN32)
         for (size_t idx = 0; idx < length; ++idx)
         {
             uint32_t temp;
@@ -425,7 +427,7 @@ std::wstring FastCdr::readWString(uint32_t &length)
     else if((m_lastPosition - m_currentPosition) >= bytesLength)
     {
 
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32) or defined(FASTCDR_ARM32)
         wchar_t* wValue = new wchar_t[length];
         deserializeArray(wValue, length);
 #else
@@ -437,7 +439,7 @@ std::wstring FastCdr::readWString(uint32_t &length)
             --length;
         }
         returnedValue = std::wstring(wValue, length);
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32) or defined(FASTCDR_ARM32)
         delete [] wValue;
 #endif
         return returnedValue;
@@ -580,7 +582,7 @@ FastCdr& FastCdr::deserializeArray(long double *ldouble_t, size_t numElements)
 
     if((m_lastPosition - m_currentPosition) >= totalSize)
     {
-#if defined(FASTCDR_32BIT)
+#if defined(_WIN32) or defined(FASTCDR_ARM32)
         for (size_t idx = 0; idx < numElements; ++idx)
         {
             m_currentPosition += 8; // Windows ignores the first 8 bytes

--- a/src/cpp/FastCdr.cpp
+++ b/src/cpp/FastCdr.cpp
@@ -90,11 +90,11 @@ FastCdr& FastCdr::serialize(const bool bool_t)
 
 FastCdr& FastCdr::serialize(const char *string_t)
 {
-    size_t length = 0;
+    uint32_t length = 0;
 
     if(string_t != nullptr)
     {
-        length = strlen(string_t) + 1;
+        length = SIZE_TO_32BIT(strlen(string_t)) + 1;
     }
 
     if(length > 0)
@@ -123,19 +123,19 @@ FastCdr& FastCdr::serialize(const char *string_t)
 
 FastCdr& FastCdr::serialize(const wchar_t *string_t)
 {
-    size_t bytesLength = 0;
+    uint32_t bytesLength = 0;
     size_t wstrlen = 0;
 
     if (string_t != nullptr)
     {
         wstrlen = wcslen(string_t);
-        bytesLength = wstrlen * 4;
+        bytesLength = SIZE_TO_32BIT(wstrlen * 4);
     }
 
     if(bytesLength > 0)
     {
         FastCdr::state state_(*this);
-        serialize(wstrlen);
+        serialize(SIZE_TO_32BIT(wstrlen));
 
         if(((m_lastPosition - m_currentPosition) >= bytesLength) || resize(bytesLength))
         {

--- a/src/cpp/FastCdr.cpp
+++ b/src/cpp/FastCdr.cpp
@@ -90,11 +90,11 @@ FastCdr& FastCdr::serialize(const bool bool_t)
 
 FastCdr& FastCdr::serialize(const char *string_t)
 {
-    uint32_t length = 0;
+    size_t length = 0;
 
     if(string_t != nullptr)
     {
-        length = static_cast<uint32_t>(strlen(string_t)) + 1;
+        length = strlen(string_t) + 1;
     }
 
     if(length > 0)
@@ -123,23 +123,23 @@ FastCdr& FastCdr::serialize(const char *string_t)
 
 FastCdr& FastCdr::serialize(const wchar_t *string_t)
 {
-    uint32_t bytesLength = 0;
+    size_t bytesLength = 0;
     size_t wstrlen = 0;
 
     if (string_t != nullptr)
     {
         wstrlen = wcslen(string_t);
-        bytesLength = static_cast<uint32_t>(wstrlen * 4);
+        bytesLength = wstrlen * 4;
     }
 
     if(bytesLength > 0)
     {
         FastCdr::state state_(*this);
-        serialize(static_cast<uint32_t>(wstrlen));
+        serialize(wstrlen);
 
         if(((m_lastPosition - m_currentPosition) >= bytesLength) || resize(bytesLength))
         {
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
             serializeArray(string_t, wstrlen);
 #else
             m_currentPosition.memcopy(string_t, bytesLength);
@@ -281,7 +281,7 @@ FastCdr& FastCdr::serializeArray(const long double *ldouble_t, size_t numElement
 
     if(((m_lastPosition - m_currentPosition) >= totalSize) || resize(totalSize))
     {
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
         for (size_t idx = 0; idx < numElements; ++idx)
         {
             m_currentPosition << static_cast<long double>(0);
@@ -367,7 +367,7 @@ FastCdr& FastCdr::deserialize(wchar_t *&string_t)
         // Allocate memory.
         string_t = reinterpret_cast<wchar_t*>(calloc(length + 1, sizeof(wchar_t))); // WStrings never serialize terminating zero
 
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
         for (size_t idx = 0; idx < length; ++idx)
         {
             uint32_t temp;
@@ -425,7 +425,7 @@ std::wstring FastCdr::readWString(uint32_t &length)
     else if((m_lastPosition - m_currentPosition) >= bytesLength)
     {
 
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
         wchar_t* wValue = new wchar_t[length];
         deserializeArray(wValue, length);
 #else
@@ -437,7 +437,7 @@ std::wstring FastCdr::readWString(uint32_t &length)
             --length;
         }
         returnedValue = std::wstring(wValue, length);
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
         delete [] wValue;
 #endif
         return returnedValue;
@@ -520,7 +520,7 @@ FastCdr& FastCdr::deserializeArray(int32_t *long_t, size_t numElements)
 
 FastCdr& FastCdr::deserializeArray(wchar_t *wchar, size_t numElements)
 {
-    uint32_t value;
+    uint32_t value = 0;
     for(size_t count = 0; count < numElements; ++count)
     {
         deserialize(value);
@@ -580,7 +580,7 @@ FastCdr& FastCdr::deserializeArray(long double *ldouble_t, size_t numElements)
 
     if((m_lastPosition - m_currentPosition) >= totalSize)
     {
-#if defined(_WIN32)
+#if defined(FASTCDR_32BIT)
         for (size_t idx = 0; idx < numElements; ++idx)
         {
             m_currentPosition += 8; // Windows ignores the first 8 bytes

--- a/src/cpp/FastCdr.cpp
+++ b/src/cpp/FastCdr.cpp
@@ -139,7 +139,6 @@ FastCdr& FastCdr::serialize(const wchar_t *string_t)
 
         if(((m_lastPosition - m_currentPosition) >= bytesLength) || resize(bytesLength))
         {
-// #if defined(FASTCDR_32BIT)
 #if defined(_WIN32)
             serializeArray(string_t, wstrlen);
 #else
@@ -368,7 +367,6 @@ FastCdr& FastCdr::deserialize(wchar_t *&string_t)
         // Allocate memory.
         string_t = reinterpret_cast<wchar_t*>(calloc(length + 1, sizeof(wchar_t))); // WStrings never serialize terminating zero
 
-// #if defined(FASTCDR_32BIT)
 #if defined(_WIN32)
         for (size_t idx = 0; idx < length; ++idx)
         {

--- a/src/cpp/FastCdr.cpp
+++ b/src/cpp/FastCdr.cpp
@@ -281,7 +281,7 @@ FastCdr& FastCdr::serializeArray(const long double *ldouble_t, size_t numElement
 
     if(((m_lastPosition - m_currentPosition) >= totalSize) || resize(totalSize))
     {
-#if defined(_WIN32) or defined(FASTCDR_ARM32)
+#if defined(_WIN32) || defined(FASTCDR_ARM32)
         for (size_t idx = 0; idx < numElements; ++idx)
         {
             m_currentPosition << static_cast<long double>(0);
@@ -425,7 +425,7 @@ std::wstring FastCdr::readWString(uint32_t &length)
     else if((m_lastPosition - m_currentPosition) >= bytesLength)
     {
 
-#if defined(_WIN32) or defined(FASTCDR_ARM32)
+#if defined(_WIN32) || defined(FASTCDR_ARM32)
         wchar_t* wValue = new wchar_t[length];
         deserializeArray(wValue, length);
 #else
@@ -437,7 +437,7 @@ std::wstring FastCdr::readWString(uint32_t &length)
             --length;
         }
         returnedValue = std::wstring(wValue, length);
-#if defined(_WIN32) or defined(FASTCDR_ARM32)
+#if defined(_WIN32) || defined(FASTCDR_ARM32)
         delete [] wValue;
 #endif
         return returnedValue;
@@ -580,7 +580,7 @@ FastCdr& FastCdr::deserializeArray(long double *ldouble_t, size_t numElements)
 
     if((m_lastPosition - m_currentPosition) >= totalSize)
     {
-#if defined(_WIN32) or defined(FASTCDR_ARM32)
+#if defined(_WIN32) || defined(FASTCDR_ARM32)
         for (size_t idx = 0; idx < numElements; ++idx)
         {
             m_currentPosition += 8; // Windows ignores the first 8 bytes


### PR DESCRIPTION
Fixes https://github.com/eProsima/Fast-CDR/issues/52

This is an attempt to fix the warnings and test failures in armhf builds.

This ROS2 build shows the warnings that were being raised https://ci.ros2.org/view/All/job/test_ci_linux-armhf/13/warnings23Result/
* Fix `useless-cast` warnings by removing unnecessary use of `uint32_t` when working with `size_t` values
* Fix `cast-align` warnings by doing `memcpy` instead of `reinterpret_cast`s
* Fix test suite by changing `_WIN32` preprocessor guards to also guard ARM32 builds

Please let me know if you would like this split out into separate changes, or if you would prefer to keep it as-is for a single review.