### PR TITLE
prevent memcpy with nullptr

### DIFF
--- a/include/fastcdr/FastBuffer.h
+++ b/include/fastcdr/FastBuffer.h
@@ -125,7 +125,9 @@ namespace eprosima
                 inline
                     void memcopy(const void* src, const size_t size)
                     {
-                        memcpy(m_currentPosition, src, size);
+                        if (size > 0) {
+                            memcpy(m_currentPosition, src, size);
+                        }
                     }
 
                 /*!
@@ -136,7 +138,9 @@ namespace eprosima
                 inline
                     void rmemcopy(void* dst, const size_t size)
                     {
-                        memcpy(dst, m_currentPosition, size);
+                        if (size > 0) {
+                            memcpy(dst, m_currentPosition, size);
+                        }
                     }
 
                 /*!


### PR DESCRIPTION
I noticed that sometimes `serializeArray` is called with 0 elements. A vector with a capacity of 0 can have data pointing to nullptr. This means that a memcpy call can occur with the first argument as nullptr. According to the [C standard](https://stackoverflow.com/a/5243068), this is undefined behavior.