### PR TITLE
fastbuffer memcpy and long double ptr fix

### DIFF
--- a/include/fastcdr/FastBuffer.h
+++ b/include/fastcdr/FastBuffer.h
@@ -92,11 +92,7 @@ namespace eprosima
                     inline
                     void operator<<(const _T &data)
                     {
-                        #if defined(FASTCDR_ARM32)
                         memcpy(m_currentPosition, &data, sizeof(_T));
-                        #else
-                        *(reinterpret_cast<_T*>(m_currentPosition)) = data;
-                        #endif
                     }
 
                 /*!
@@ -108,13 +104,7 @@ namespace eprosima
                     inline
                     void operator>>(_T &data)
                     {
-                        #if defined(FASTCDR_ARM32)
-                        _T val;
-                        memcpy(&val, m_currentPosition, sizeof(_T));
-                        data = val;
-                        #else
-                        data = *(reinterpret_cast<_T*>(m_currentPosition));
-                        #endif
+                        memcpy(&data, m_currentPosition, sizeof(_T));
                     }
 
                 /*!

--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -2249,7 +2249,7 @@ Cdr& Cdr::deserializeArray(long double *ldouble_t, size_t numElements)
 
         if(m_swapBytes)
         {
-            char *dst = reinterpret_cast<char*>(&ldouble_t);
+            char *dst = reinterpret_cast<char*>(ldouble_t);
             char *end = dst + totalSize;
 
             for(; dst < end; dst += sizeof(*ldouble_t))


### PR DESCRIPTION
Here's a suggested fix for https://github.com/eProsima/Fast-CDR/issues/64.

In src/cpp/Cdr.cpp, there appears to be a bug where a `long double **` was set instead of a `long double *`. The warnings were from "-Wstringop-overflow=" in gcc 9.2, after changing to `memcpy.`