### PR TITLE
Custom exceptions made allocation free and noexcept.

### DIFF
--- a/include/fastcdr/exceptions/BadParamException.h
+++ b/include/fastcdr/exceptions/BadParamException.h
@@ -34,16 +34,16 @@ namespace eprosima
                     /*!
                      * @brief Default constructor.
                      *
-                     * @param message A error message. This message is copied.
+                     * @param message A error message. This message pointer is copied.
                      */
-                    Cdr_DllAPI BadParamException(const char* const &message);
+                    Cdr_DllAPI BadParamException(const char* const &message) noexcept;
 
                     /*!
                      * @brief Default copy constructor.
                      *
                      * @param ex BadParamException that will be copied.
                      */
-                    Cdr_DllAPI BadParamException(const BadParamException &ex);
+                    Cdr_DllAPI BadParamException(const BadParamException &ex) noexcept;
 
 #if HAVE_CXX0X
                     /*!
@@ -51,7 +51,7 @@ namespace eprosima
                      *
                      * @param ex BadParamException that will be moved.
                      */
-                    Cdr_DllAPI BadParamException(BadParamException&& ex);
+                    Cdr_DllAPI BadParamException(BadParamException&& ex) noexcept;
 #endif
 
                     /*!
@@ -59,7 +59,7 @@ namespace eprosima
                      *
                      * @param ex BadParamException that will be copied.
                      */
-                    Cdr_DllAPI BadParamException& operator=(const BadParamException &ex);
+                    Cdr_DllAPI BadParamException& operator=(const BadParamException &ex) noexcept;
 
 #if HAVE_CXX0X
                     /*!
@@ -67,11 +67,11 @@ namespace eprosima
                      *
                      * @param ex BadParamException that will be moved.
                      */
-                    BadParamException& operator=(BadParamException&& ex);
+                    BadParamException& operator=(BadParamException&& ex) noexcept;
 #endif
 
                     //! @brief Default constructor
-                    virtual Cdr_DllAPI ~BadParamException() throw();
+                    virtual Cdr_DllAPI ~BadParamException() noexcept;
 
                     //! @brief This function throws the object as exception.
                     virtual Cdr_DllAPI void raise() const;

--- a/include/fastcdr/exceptions/Exception.h
+++ b/include/fastcdr/exceptions/Exception.h
@@ -34,7 +34,7 @@ namespace eprosima
                 public:
 
                     //! \brief Default destructor.
-                    virtual Cdr_DllAPI ~Exception() throw();
+                    virtual Cdr_DllAPI ~Exception() noexcept;
 
                     //! \brief This function throws the object as exception.
                     virtual Cdr_DllAPI void raise() const = 0;
@@ -44,23 +44,23 @@ namespace eprosima
                      *
                      * @return The error message.
                      */
-                    virtual Cdr_DllAPI const char* what() const throw() ;
+                    virtual Cdr_DllAPI const char* what() const noexcept ;
 
                 protected:
 
                     /*!
                      * @brief Default constructor.
                      *
-                     * @param message A error message. This message is copied.
+                     * @param message A error message. This message pointer is copied.
                      */
-                    Cdr_DllAPI Exception(const char* const &message);
+                    Cdr_DllAPI Exception(const char* const &message) noexcept;
 
                     /*!
                      * @brief Default copy constructor.
                      *
                      * @param ex Exception that will be copied.
                      */
-                    Cdr_DllAPI Exception(const Exception &ex);
+                    Cdr_DllAPI Exception(const Exception &ex) noexcept;
 
 #if HAVE_CXX0X
                     /*!
@@ -68,7 +68,7 @@ namespace eprosima
                      *
                      * @param ex Exception that will be moved.
                      */
-                    Cdr_DllAPI Exception(Exception&& ex);
+                    Cdr_DllAPI Exception(Exception&& ex) noexcept;
 #endif
 
                     /*!
@@ -76,7 +76,7 @@ namespace eprosima
                      *
                      * @param ex Exception that will be copied.
                      */
-                    Cdr_DllAPI Exception& operator=(const Exception &ex);
+                    Cdr_DllAPI Exception& operator=(const Exception &ex) noexcept;
 
 #if HAVE_CXX0X
                     /*!
@@ -84,12 +84,12 @@ namespace eprosima
                      *
                      * @param ex Exception that will be moved.
                      */
-                    Cdr_DllAPI Exception& operator=(Exception&&);
+                    Cdr_DllAPI Exception& operator=(Exception&&) noexcept;
 #endif
 
                 private:
 
-                    std::string m_message;
+                    const char* m_message;
             };
         } //namespace exception
     } //namespace fastcdr

--- a/include/fastcdr/exceptions/NotEnoughMemoryException.h
+++ b/include/fastcdr/exceptions/NotEnoughMemoryException.h
@@ -34,16 +34,16 @@ namespace eprosima
                     /*!
                      * @brief Default constructor.
                      *
-                     * @param message A error message. This message is copied.
+                     * @param message A error message. This message pointer is copied.
                      */
-                    Cdr_DllAPI NotEnoughMemoryException(const char* const &message);
+                    Cdr_DllAPI NotEnoughMemoryException(const char* const &message) noexcept;
 
                     /*!
                      * @brief Default copy constructor.
                      *
                      * @param ex NotEnoughMemoryException that will be copied.
                      */
-                    Cdr_DllAPI NotEnoughMemoryException(const NotEnoughMemoryException &ex);
+                    Cdr_DllAPI NotEnoughMemoryException(const NotEnoughMemoryException &ex) noexcept;
 
 #if HAVE_CXX0X
                     /*!
@@ -51,7 +51,7 @@ namespace eprosima
                      *
                      * @param ex NotEnoughMemoryException that will be moved.
                      */
-                    Cdr_DllAPI NotEnoughMemoryException(NotEnoughMemoryException&& ex);
+                    Cdr_DllAPI NotEnoughMemoryException(NotEnoughMemoryException&& ex) noexcept;
 #endif
 
                     /*!
@@ -59,7 +59,7 @@ namespace eprosima
                      *
                      * @param ex NotEnoughMemoryException that will be copied.
                      */
-                    Cdr_DllAPI NotEnoughMemoryException& operator=(const NotEnoughMemoryException &ex);
+                    Cdr_DllAPI NotEnoughMemoryException& operator=(const NotEnoughMemoryException &ex) noexcept;
 
 #if HAVE_CXX0X
                     /*!
@@ -67,11 +67,11 @@ namespace eprosima
                      *
                      * @param ex NotEnoughMemoryException that will be moved.
                      */
-                    Cdr_DllAPI NotEnoughMemoryException& operator=(NotEnoughMemoryException&& ex);
+                    Cdr_DllAPI NotEnoughMemoryException& operator=(NotEnoughMemoryException&& ex) noexcept;
 #endif
 
                     //! @brief Default constructor
-                    virtual Cdr_DllAPI ~NotEnoughMemoryException() throw();
+                    virtual Cdr_DllAPI ~NotEnoughMemoryException() noexcept;
 
                     //! @brief This function throws the object as exception.
                     virtual Cdr_DllAPI void raise() const;

--- a/src/cpp/exceptions/BadParamException.cpp
+++ b/src/cpp/exceptions/BadParamException.cpp
@@ -18,21 +18,21 @@ using namespace eprosima::fastcdr::exception;
 
 const char* const BadParamException::BAD_PARAM_MESSAGE_DEFAULT ="Bad parameter";
 
-BadParamException::BadParamException(const char* const &message) : Exception(message)
+BadParamException::BadParamException(const char* const &message) noexcept : Exception(message)
 {
 }
 
-BadParamException::BadParamException(const BadParamException &ex) : Exception(ex)
+BadParamException::BadParamException(const BadParamException &ex) noexcept : Exception(ex)
 {
 }
 
 #if HAVE_CXX0X
-BadParamException::BadParamException(BadParamException&& ex) : Exception(std::move(ex))
+BadParamException::BadParamException(BadParamException&& ex) noexcept : Exception(std::move(ex))
 {
 }
 #endif
 
-BadParamException& BadParamException::operator=(const BadParamException &ex)
+BadParamException& BadParamException::operator=(const BadParamException &ex) noexcept
 {
     if(this != &ex)
     {
@@ -43,7 +43,7 @@ BadParamException& BadParamException::operator=(const BadParamException &ex)
 }
 
 #if HAVE_CXX0X
-BadParamException& BadParamException::operator=(BadParamException&& ex)
+BadParamException& BadParamException::operator=(BadParamException&& ex) noexcept
 {
     if(this != &ex)
     {
@@ -54,7 +54,7 @@ BadParamException& BadParamException::operator=(BadParamException&& ex)
 }
 #endif
 
-BadParamException::~BadParamException() throw()
+BadParamException::~BadParamException() noexcept
 {
 }
 

--- a/src/cpp/exceptions/Exception.cpp
+++ b/src/cpp/exceptions/Exception.cpp
@@ -16,39 +16,39 @@
 
 using namespace eprosima::fastcdr::exception;
 
-Exception::Exception(const char* const &message) : m_message(message)
+Exception::Exception(const char* const &message) noexcept : m_message(message)
 {
 }
 
-Exception::Exception(const Exception &ex) : m_message(ex.m_message)
+Exception::Exception(const Exception &ex) noexcept : m_message(ex.m_message)
 {
 }
 
 #if HAVE_CXX0X
-Exception::Exception(Exception&& ex) : m_message(std::move(ex.m_message))
+Exception::Exception(Exception&& ex) noexcept : m_message(std::move(ex.m_message))
 {
 }
 #endif
 
-Exception& Exception::operator=(const Exception &ex)
+Exception& Exception::operator=(const Exception &ex) noexcept
 {
     m_message = ex.m_message;
     return *this;
 }
 
 #if HAVE_CXX0X
-Exception& Exception::operator=(Exception&& ex)
+Exception& Exception::operator=(Exception&& ex) noexcept
 {
     m_message = std::move(ex.m_message);
     return *this;
 }
 #endif
 
-Exception::~Exception() throw()
+Exception::~Exception() noexcept
 {
 }
 
-const char* Exception::what() const throw()
+const char* Exception::what() const noexcept
 {
-    return m_message.c_str();
+    return m_message;
 }

--- a/src/cpp/exceptions/NotEnoughMemoryException.cpp
+++ b/src/cpp/exceptions/NotEnoughMemoryException.cpp
@@ -18,21 +18,21 @@ using namespace eprosima::fastcdr::exception;
 
 const char* const NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT = "Not enough memory in the buffer stream";
 
-NotEnoughMemoryException::NotEnoughMemoryException(const char* const &message) : Exception(message)
+NotEnoughMemoryException::NotEnoughMemoryException(const char* const &message) noexcept : Exception(message) 
 {
 }
 
-NotEnoughMemoryException::NotEnoughMemoryException(const NotEnoughMemoryException &ex) : Exception(ex)
+NotEnoughMemoryException::NotEnoughMemoryException(const NotEnoughMemoryException &ex) noexcept : Exception(ex)
 {
 }
 
 #if HAVE_CXX0X
-NotEnoughMemoryException::NotEnoughMemoryException(NotEnoughMemoryException&& ex) : Exception(std::move(ex))
+NotEnoughMemoryException::NotEnoughMemoryException(NotEnoughMemoryException&& ex) noexcept : Exception(std::move(ex))
 {
 }
 #endif
 
-NotEnoughMemoryException& NotEnoughMemoryException::operator=(const NotEnoughMemoryException &ex)
+NotEnoughMemoryException& NotEnoughMemoryException::operator=(const NotEnoughMemoryException &ex) noexcept
 {
     if(this != &ex)
     {
@@ -43,7 +43,7 @@ NotEnoughMemoryException& NotEnoughMemoryException::operator=(const NotEnoughMem
 }
 
 #if HAVE_CXX0X
-NotEnoughMemoryException& NotEnoughMemoryException::operator=(NotEnoughMemoryException&& ex)
+NotEnoughMemoryException& NotEnoughMemoryException::operator=(NotEnoughMemoryException&& ex) noexcept
 {
     if(this != &ex)
     {
@@ -54,7 +54,7 @@ NotEnoughMemoryException& NotEnoughMemoryException::operator=(NotEnoughMemoryExc
 }
 #endif
 
-NotEnoughMemoryException::~NotEnoughMemoryException() throw()
+NotEnoughMemoryException::~NotEnoughMemoryException() noexcept
 {
 }
 


### PR DESCRIPTION
This PR changes the custom exceptions of Fast CDR to keep a `const char *` instead of a `std::string` so they can be made allocation free and noexcept.