### PR TITLE
add preprocessing guards for __FreeBSD__ alongside __APPLE__

### DIFF
--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -24,7 +24,7 @@
 #include <map>
 #include <iostream>
 
-#if !__APPLE__
+#if !__APPLE__ && !__FreeBSD__
 #include <malloc.h>
 #else
 #include <stdlib.h>

--- a/include/fastcdr/FastCdr.h
+++ b/include/fastcdr/FastCdr.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-#if !__APPLE__
+#if !__APPLE__ && !__FreeBSD__
 #include <malloc.h>
 #else
 #include <stdlib.h>

--- a/src/cpp/FastBuffer.cpp
+++ b/src/cpp/FastBuffer.cpp
@@ -14,7 +14,7 @@
 
 #include <fastcdr/FastBuffer.h>
 
-#if !__APPLE__
+#if !__APPLE__ && !__FreeBSD__
 #include <malloc.h>
 #else
 #include <stdlib.h>


### PR DESCRIPTION
For cross-compilation to FreeBSD, `stdlib.h` should be used in place of `malloc.h`, similar to compilations targeting Apple products.