### PR TITLE
Set and check endianness with FASTCDR_IS_BIG_ENDIAN_TARGET

### DIFF
--- a/cmake/common/check_configuration.cmake
+++ b/cmake/common/check_configuration.cmake
@@ -76,7 +76,7 @@ macro(check_endianness)
     # Test endianness
     include(TestBigEndian)
     test_big_endian(BIG_ENDIAN)
-    set(__BIG_ENDIAN__ ${BIG_ENDIAN})
+    set(FASTCDR_IS_BIG_ENDIAN_TARGET ${BIG_ENDIAN})
 endmacro()
 
 macro(check_msvc_arch)

--- a/configure.ac
+++ b/configure.ac
@@ -47,8 +47,8 @@ AS_IF([test $HAVE_CXX11 = 1],
 
 # Check endianess
 AC_C_BIGENDIAN(
-  AC_DEFINE(__BIG_ENDIAN__, 1, [machine is bigendian]),
-  AC_DEFINE(__BIG_ENDIAN__, 0, [machine is littleendian]),
+  AC_DEFINE(FASTCDR_IS_BIG_ENDIAN_TARGET, 1, [machine is bigendian]),
+  AC_DEFINE(FASTCDR_IS_BIG_ENDIAN_TARGET, 0, [machine is littleendian]),
   AC_MSG_ERROR(unknown endianess),
   AC_MSG_ERROR(universial endianess not supported)
 )

--- a/include/fastcdr/config.h.in
+++ b/include/fastcdr/config.h.in
@@ -42,8 +42,8 @@
 #endif
 
 // Endianness defines
-#ifndef __BIG_ENDIAN__
-#define __BIG_ENDIAN__ @__BIG_ENDIAN__@
+#ifndef FASTCDR_IS_BIG_ENDIAN_TARGET
+#define FASTCDR_IS_BIG_ENDIAN_TARGET @FASTCDR_IS_BIG_ENDIAN_TARGET@
 #endif
 
 #if defined(__ARM_ARCH) && __ARM_ARCH <= 7

--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -18,7 +18,7 @@
 using namespace eprosima::fastcdr;
 using namespace ::exception;
 
-#if __BIG_ENDIAN__
+#if FASTCDR_IS_BIG_ENDIAN_TARGET
 const Cdr::Endianness Cdr::DEFAULT_ENDIAN = BIG_ENDIANNESS;
 #else
 const Cdr::Endianness Cdr::DEFAULT_ENDIAN = LITTLE_ENDIANNESS;


### PR DESCRIPTION
config.h was defining `__BIG_ENDIAN__` macro, setting it to 0 or 1. This can cause problems with other libraries that check endianness by simply `#if defined(__BIG_ENDIAN__)`. In any case, defining macros `__*__` is generally not a good practices, since they are supposed to be reserved for the compiler. The PR changes `__BIG_ENDIAN__` for `FASTCDR_IS_BIG_ENDIAN_TARGET` to internally check for endianness.

This PR is related to eprosima/Fast-DDS#1001.

Signed-off-by: EduPonz <eduardoponz@eprosima.com>