### PR TITLE
Add GCC support for compiling with hidden visibility

### DIFF
--- a/include/fastcdr/fastcdr_dll.h
+++ b/include/fastcdr/fastcdr_dll.h
@@ -48,7 +48,11 @@
 #define Cdr_DllAPI
 #endif // if defined(EPROSIMA_ALL_DYN_LINK) || defined(FASTCDR_DYN_LINK)
 #else
+#if __GNUC__ >= 4
+#define Cdr_DllAPI __attribute__((visibility("default")))
+#else
 #define Cdr_DllAPI
+#endif // if __GNUC__ >= 4
 #endif // _WIN32
 
 // Auto linking.


### PR DESCRIPTION
GCC hidden visibility closely mimics the Windows DLL import/export
feature, which cleans up the symbol export table and leads to faster
startup times as well as a more stable ABI.

This PR has no immediate effect until GCC is instructed to hide symbols
with -fvisibility=hidden -fvisibility-inlines-hidden. I did not enable
this yet because unlike MSVC, GCC does not export type info and vtables
by default, so this PR depends on #88 to work.

Signed-off-by: Timo Röhling <timo@gaussglocke.de>