### PR TITLE
Code coverage policy [10027]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,14 @@
-Any contribution that you make to this repository will
-be under the Apache 2 License, as dictated by that
-[license](http://www.apache.org/licenses/LICENSE-2.0.html):
+# Contribution Guidelines
+
+The following documents constitutes a set of guidelines to which contributors must adhere.
+
+* [Contributions Licensing](#contributions-licensing)
+* [Developer Certificate of Origin](#developer-certificate-of-origin)
+* [Code Coverage](#code-coverage)
+
+## Contributions Licensing
+
+Any contribution that you make to this repository will be under the Apache 2 License, as dictated by that [license](http://www.apache.org/licenses/LICENSE-2.0.html):
 
 ~~~
 5. Submission of Contributions. Unless You explicitly state otherwise,
@@ -12,7 +20,11 @@ be under the Apache 2 License, as dictated by that
    with Licensor regarding such Contributions.
 ~~~
 
-Contributors must sign-off each commit by adding a `Signed-off-by: ...`
-line to commit messages to certify that they have the right to submit
-the code they are contributing to the project according to the
-[Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+## Developer Certificate of Origin
+
+Contributors must sign-off each commit by adding a `Signed-off-by: ...` line to commit messages to certify that they have the right to submit the code they are contributing to the project according to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+
+## Code Coverage
+
+As stated in [QUALITY.md](QUALITY.md), all contributions to the project must increase line code coverage.
+Because of this, contributors are asked to locally run a coverage assessment that ensures that code coverage has increased when compared to the latest execution of the [nightly coverage CI job](http://jenkins.eprosima.com:8080/job/nightly_fastdds_coverage_linux/).

--- a/QUALITY.md
+++ b/QUALITY.md
@@ -116,8 +116,8 @@ The tests aim to cover typical usage and corner cases.
 *eProsima Fast CDR* aims to provide a line coverage **above 95%**.
 *Fast CDR* code coverage policy comprises:
 1. All contributions to *Fast CDR* must increase (or at least keep) current line coverage.
-   This is done to ensure that the **95%** line coverage goal is in time met.
-1. Line coverage regressions only are permitted if properly justified and accepted by maintainers.
+   This is done to ensure that the **95%** line coverage goal is eventually met.
+1. Line coverage regressions are only permitted if properly justified and accepted by maintainers.
 1. If the CI system reports a coverage regression after a pull request has been merged, the maintainers must study the case and decide how to proceed, mostly reverting the changes and asking for a more thorough testing of the committed changes.
 1. This policy is enforced through the [nightly Fast CDR coverage CI job](http://jenkins.eprosima.com:8080/job/nightly_fastcdr_coverage_linux/).
 

--- a/QUALITY.md
+++ b/QUALITY.md
@@ -1,7 +1,6 @@
 This document is a declaration of software quality for **eProsima Fast CDR** based on the guidelines provided in the [ROS 2 REP-2004 document](https://www.ros.org/reps/rep-2004.html).
 
-Quality Declaration
-=============================
+# Quality Declaration
 
 **eProsima Fast CDR** is a C++ library that provides two serialization mechanisms.
 One is the [standard CDR](https://www.omg.org/cgi-bin/doc?formal/02-06-51) serialization mechanism, while the other is a faster implementation that modifies the standard.
@@ -113,12 +112,16 @@ The tests aim to cover typical usage and corner cases.
 
 ### Coverage [4.iii]
 
-**eProsima Fast CDR** coverage reports can be accessed from the Linux CI nightly results. These reports provide statistics of line and conditional coverage.
+[![Coverage](https://img.shields.io/jenkins/coverage/cobertura.svg?jobUrl=http%3A%2F%2Fjenkins.eprosima.com%3A8080%2Fjob%2Fnightly_fastcdr_coverage_linux)](http://jenkins.eprosima.com:8080/job/nightly_fastcdr_coverage_linux)
+*eProsima Fast CDR* aims to provide a line coverage **above 95%**.
+*Fast CDR* code coverage policy comprises:
+1. All contributions to *Fast CDR* must increase (or at least keep) current line coverage.
+   This is done to ensure that the **95%** line coverage goal is in time met.
+1. Line coverage regressions only are permitted if properly justified and accepted by maintainers.
+1. If the CI system reports a coverage regression after a pull request has been merged, the maintainers must study the case and decide how to proceed, mostly reverting the changes and asking for a more thorough testing of the committed changes.
+1. This policy is enforced through the [nightly Fast CDR coverage CI job](http://jenkins.eprosima.com:8080/job/nightly_fastcdr_coverage_linux/).
 
-* [Linux Coverage Report](http://jenkins.eprosima.com:8080/view/Nightly/job/nightly_fastcdr_master_linux/4/cobertura/)
-* [Mac Coverage Report](http://jenkins.eprosima.com:8080/view/Nightly/job/nightly_fastcdr_master_mac/2/cobertura/)
-
-Changes are required to make a best effort to keep or increase coverage before being accepted, but decreases are allowed if properly justified and accepted by maintainers.
+As stated in [CONTRIBUTING.md](CONTRIBUTING.md), developers and contributors are asked to run a line coverage assessment locally before submitting a PR.
 
 ### Performance [4.iv]
 
@@ -187,7 +190,7 @@ The chart below compares the requirements in the [REP-2004](https://www.ros.org/
 |4.i| Feature items tests |✓|
 |4.ii| Public API tests |✓|
 |4.iii.a| Using coverage |✓|
-|4.iii.b| Coverage policy ||
+|4.iii.b| Coverage policy |✓|
 |4.iv.a| Performance tests (if applicable) |N/A|
 |4.iv.b| Performance tests policy|N/A|
 |4.v.a| Code style enforcement (linters)|✓|

--- a/README.md
+++ b/README.md
@@ -1,14 +1,28 @@
-# Introduction #
+# Fast CDR
 
-**eProsima Fast CDR** is a C++ library that provides two serialization mechanisms. One is the standard CDR serialization mechanism, while the other is a faster implementation that modifies the standard.
+[![License](https://img.shields.io/github/license/eProsima/Fast-CDR.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Releases](https://img.shields.io/github/v/release/eProsima/Fast-CDR?sort=semver)](https://github.com/eProsima/Fast-CDR/releases)
+[![Issues](https://img.shields.io/github/issues/eProsima/Fast-CDR.svg)](https://github.com/eProsima/Fast-CDR/issues)
+[![Forks](https://img.shields.io/github/forks/eProsima/Fast-CDR.svg)](https://github.com/eProsima/Fast-CDR/network/members)
+[![Stars](https://img.shields.io/github/stars/eProsima/Fast-CDR.svg)](https://github.com/eProsima/Fast-CDR/stargazers)
+[![Linux ci](http://jenkins.eprosima.com:8080/job/nightly_fastcdr_master_linux/badge/icon?subject=%20%20%20Linux%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastcdr_master_linux)
+[![Linux arm64 ci](http://jenkins.eprosima.com:8080/job/nightly_fastcdr_master_linux_aarch64/badge/icon?subject=%20%20%20Linux-aarch64%20CI%20)](http://jenkins.eprosima.com:8080/view/Nightly/job/nightly_fastcdr_master_linux_aarch64/)
+[![Windows ci](http://jenkins.eprosima.com:8080/job/nightly_fastcdr_master_windows/label=windows-secure,platform=x64,toolset=v141/badge/icon?subject=%20%20%20%20Windows%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastcdr_master_windows/label=windows-secure,platform=x64,toolset=v141)
+[![Mac ci](http://jenkins.eprosima.com:8080/job/nightly_fastcdr_master_mac/badge/icon?subject=%20%20%20%20%20%20%20Mac%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastcdr_master_mac)
+[![Coverage](https://img.shields.io/jenkins/coverage/cobertura.svg?jobUrl=http%3A%2F%2Fjenkins.eprosima.com%3A8080%2Fjob%2Fnightly_fastcdr_coverage_linux)](http://jenkins.eprosima.com:8080/job/nightly_fastcdr_coverage_linux)
 
-# Build #
+**eProsima Fast CDR** is a C++ library that provides two serialization mechanisms.
+One is the standard CDR serialization mechanism, while the other is a faster implementation that modifies the standard.
 
-**eProsima Fast CDR** provides [CMake][cmake] scripts to build and install it. Also in [eProsima][eprosima] you can find packages for Linux using autotools and binaries for Windows.
+## Build
+
+**eProsima Fast CDR** provides [CMake][cmake] scripts to build and install it.
+Also in [eProsima][eprosima] you can find packages for Linux using autotools and binaries for Windows.
 
 [cmake]: http://www.cmake.org
 [eprosima]: http://www.eprosima.com
 
-# Quality Declaration #
+## Quality Declaration
 
-**eprosima Fast CDR** claims to be in the **Quality Level 2** category based on the guidelines provided by [ROS 2](https://ros.org/reps/rep-2004.html). See the [Quality Declaration](QUALITY.md) for more details.
+**eprosima Fast CDR** claims to be in the **Quality Level 2** category based on the guidelines provided by [ROS 2](https://ros.org/reps/rep-2004.html).
+See the [Quality Declaration](QUALITY.md) for more details.


### PR DESCRIPTION
This PR adds a code coverage policy which states that all contributions must at least keep (if not increase) the project's line coverage.

Signed-off-by: EduPonz <eduardoponz@eprosima.com>