### PR TITLE
Update the CMake minimum required to 2.8.12.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 ###############################################################################
 # CMake build rules for FastCDR                                               #
 ###############################################################################
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.12)
 
 set(IS_TOP_LEVEL TRUE)
 if(PROJECT_SOURCE_DIR)


### PR DESCRIPTION
This is to remove a warning that happens on modern CMake
(> 3.19), and shouldn't really cause too many compatibility
problems.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix one of the two warnings on ROS 2 Windows builds: https://ci.ros2.org/view/nightly/job/nightly_win_rel/1769/cmake/