### PR TITLE
Prevent unexpected length_error exception

### DIFF
--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -2656,11 +2656,11 @@ Cdr& Cdr::deserializeBoolSequence(
 
     *this >> seqLength;
 
-    vector_t.resize(seqLength);
     size_t totalSize = seqLength * sizeof(bool);
 
     if ((m_lastPosition - m_currentPosition) >= totalSize)
     {
+        vector_t.resize(seqLength);
         // Save last datasize.
         m_lastDataSize = sizeof(bool);
 

--- a/src/cpp/FastCdr.cpp
+++ b/src/cpp/FastCdr.cpp
@@ -731,11 +731,11 @@ FastCdr& FastCdr::deserializeBoolSequence(
 
     *this >> seqLength;
 
-    vector_t.resize(seqLength);
     size_t totalSize = seqLength * sizeof(bool);
 
     if ((m_lastPosition - m_currentPosition) >= totalSize)
     {
+        vector_t.resize(seqLength);
         for (uint32_t count = 0; count < seqLength; ++count)
         {
             uint8_t value = 0;


### PR DESCRIPTION
On 32-bit architectures, `std::vector<bool>` has a `max_size()` below 2^32-1,
so the early `resize()` call will throw a length_error exception before
the deserialization code has a chance to throw the
`NotEnoughMemoryException`. This patch moves the `resize()` operation after
the length check, so the correct exception is thrown consistently.