### PR TITLE
Make $<INSTALL_INTERFACE... use INCLUDE_INSTALL_DIR, and install headers to include/${PROJECT_NAME}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ endif()
 # Installation paths
 ###############################################################################
 set(BIN_INSTALL_DIR bin/ CACHE PATH "Installation directory for binaries")
-set(INCLUDE_INSTALL_DIR include/ CACHE PATH "Installation directory for C++ headers")
+set(INCLUDE_INSTALL_DIR include/${PROJECT_NAME} CACHE PATH "Installation directory for C++ headers")
 set(LIB_INSTALL_DIR lib${LIB_SUFFIX}/ CACHE PATH "Installation directory for libraries")
 set(DATA_INSTALL_DIR share/ CACHE PATH "Installation directory for data")
 if(WIN32)

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -57,7 +57,7 @@ elseif(NOT EPROSIMA_INSTALLER)
     # Define public headers
     target_include_directories(${PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-        $<INSTALL_INTERFACE:include>
+        $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>
         )
 
     if(MSVC OR MSVC_IDE)


### PR DESCRIPTION
The first commit is a bug fix. The exported targets currently always say the include directory is `include/` regardless of `INCLUDE_INSTALL_DIR`.

The second commit is an enhancement supporting ros2/ros2#1150. When using ROS 2 and Colcon it's possible to have two versions of a package installed: typically one from the debian packages (like `ros-[rosdistro]-fastcdr`) and another in a from-source workspace. In Colcon terms this is called "overriding a package", and the `/opt/ros/[rosdistro]` folder would be called the **underlay** while the from-source workspace would be called the **overlay**. A user would do this when they want to try a newer version of a package without building everything from source.

When two or more packages install their headers to the same directory in an underlay, it becomes possible for packages in the overlay to accidentally find the headers of an overridden package in the underlay. This can cause build failures or undefined behavior at runtime depending on the differences between the headers in the overridden and overriding packages. The exact conditions this happens are a little complicated, so I'll skip writing it out here. In ROS 2 we're solving the issue by making every package install its headers to a unique folder using `${PROJECT_NAME}`. That's what the second commit does here.