### PR TITLE
[14101] Upgrading CMake c++ standard management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,6 @@ include(${PROJECT_SOURCE_DIR}/cmake/common/check_configuration.cmake)
 set(FORCE_CXX "11" CACHE STRING "C++ standard fulfillment selection")
 check_stdcxx(${FORCE_CXX})
 
-check_compile_feature()
 check_endianness()
 check_type_sizes()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 ###############################################################################
 # CMake build rules for FastCDR                                               #
 ###############################################################################
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.16.3)
 
 set(IS_TOP_LEVEL TRUE)
 if(PROJECT_SOURCE_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,10 @@ endif()
 # Test system configuration
 ###############################################################################
 include(${PROJECT_SOURCE_DIR}/cmake/common/check_configuration.cmake)
-check_stdcxx()
+
+set(FORCE_CXX "11" CACHE STRING "C++ standard fulfillment selection")
+check_stdcxx(${FORCE_CXX})
+
 check_compile_feature()
 check_endianness()
 check_type_sizes()

--- a/cmake/common/check_configuration.cmake
+++ b/cmake/common/check_configuration.cmake
@@ -12,55 +12,112 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-macro(check_stdcxx)
-    # Check C++11
-    include(CheckCXXCompilerFlag)
-    if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
-        CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
-        CMAKE_CXX_COMPILER_ID MATCHES "QCC")
-        check_cxx_compiler_flag(-std=c++14 SUPPORTS_CXX14)
-        set(HAVE_CXX14 0)
-        set(HAVE_CXX1Y 0)
-        set(HAVE_CXX11 0)
-        set(HAVE_CXX0X 0)
-        if(SUPPORTS_CXX14)
-            add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=c++14>)
-            set(HAVE_CXX14 1)
-            set(HAVE_CXX1Y 1)
-            set(HAVE_CXX11 1)
-            set(HAVE_CXX0X 1)
-        else()
-            check_cxx_compiler_flag(-std=c++1y SUPPORTS_CXX1Y)
-            if(SUPPORTS_CXX1Y)
-                add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=c++1y>)
-                set(HAVE_CXX1Y 1)
-                set(HAVE_CXX11 1)
-                set(HAVE_CXX0X 1)
-            else()
-                check_cxx_compiler_flag(-std=c++11 SUPPORTS_CXX11)
-                if(SUPPORTS_CXX11)
-                    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=c++11>)
-                    set(HAVE_CXX11 1)
-                    set(HAVE_CXX0X 1)
-                else()
-                    check_cxx_compiler_flag(-std=c++0x SUPPORTS_CXX0X)
-                    if(SUPPORTS_CXX0X)
-                        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=c++0x>)
-                        set(HAVE_CXX0X 1)
-                    else()
-                        set(HAVE_CXX0X 0)
-                    endif()
-                endif()
-            endif()
+# get_set_stdcxx() checks and sets the compiler standard level
+#   stdversion: the level of standard fullfilment
+#   stdfeature: the feature name associated with that level
+#   gcc_flag:   the gcc/clang flag for fallback
+#   cl_flag:    the cl flag for fallback
+#   force:      if the user should enforced this standard level or not (FORCE_CXX)
+#   result:     a return variable to check if this level is available
+
+function(get_set_stdcxx stdversion stdfeature gcc_flag cl_flag force result)
+
+    set(${result} 0 PARENT_SCOPE)
+
+    # check if CMake feature management is available
+    get_property(CXX_KNOWN_FEATURES GLOBAL PROPERTY CMAKE_CXX_KNOWN_FEATURES)
+    if(stdfeature IN_LIST CXX_KNOWN_FEATURES)
+        # CMake is aware let's check if is available
+        if(force AND (stdfeature IN_LIST CMAKE_CXX_COMPILE_FEATURES))
+            # is available report and enforce as commanded
+            set(CMAKE_CXX_STANDARD ${stdversion})
+            set(${result} 1 PARENT_SCOPE)
+            message(STATUS "Enforced ${stdfeature} CMake feature")
+        elseif(force)
+            message(FATAL_ERROR "The specified C++ ${stdfeature} feature is not supported using default compiler.")
         endif()
-    elseif(MSVC OR MSVC_IDE)
-        set(HAVE_CXX11 1)
-        set(HAVE_CXX0X 1)
     else()
-        set(HAVE_CXX11 0)
-        set(HAVE_CXX0X 0)
-    endif()
-endmacro()
+        # fallback to the old behaviour
+        include(CheckCXXCompilerFlag)
+
+        if(gcc_flag AND (
+           CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG OR
+           CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
+           CMAKE_CXX_COMPILER_ID MATCHES "QCC"))
+           # check using gcc/clang flags
+            check_cxx_compiler_flag(${gcc_flag} SUPPORTS_CXX)
+            if(SUPPORTS_CXX AND force)
+                add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${gcc_flag}>)
+                set(${result} 1 PARENT_SCOPE)
+                message(STATUS "Enforced ${gcc_flag} CMake feature")
+            elseif((NOT SUPPORTS_CXX) AND force)
+                message(FATAL_ERROR "Force to support ${stdfeature} but not supported by gnu compiler")
+            endif()
+        elseif(cl_flag AND (MSVC OR MSVC_IDE))
+           # check using cl flags
+            check_cxx_compiler_flag(${cl_flag} SUPPORTS_CXX)
+            if(SUPPORTS_CXX AND force)
+                add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${cl_flag}>)
+                set(${result} 1 PARENT_SCOPE)
+                message(STATUS "Enforced ${cl_flag} CMake feature")
+            elseif((NOT SUPPORTS_CXX) AND force)
+                message(FATAL_ERROR "Force to support ${stdfeature} but not supported by MSVC")
+            endif()
+       elseif(force)
+           message(WARNING "The specified C++ ${stdfeature} feature is not supported using default compiler.")
+       endif()
+
+endif()
+
+endfunction()
+
+function(check_stdcxx enforced_level)
+
+    # keep in mind -std=c++1y support for gcc/clang
+
+    # Map force values to cmake features
+    set(cxx_levels 23 20 17 14 1Y 11)
+    set(cxx_features cxx_std_23 cxx_std_20 cxx_std_17 cxx_std_14 NOTFOUND cxx_std_11)
+    set(gcc_flags -std=c++23 -std=c++20 -std=c++17 -std=c++14 -std=c++1y -std:c++11)
+    set(cl_flags /std=c++23 /std=c++20 /std=c++17 /std=c++14 NOTFOUND NOTFOUND)
+    set(HAVE_CXX HAVE_CXX23 HAVE_CXX20 HAVE_CXX17 HAVE_CXX14 HAVE_CXX1Y HAVE_CXX11)
+
+    # Traverse the collection
+    while(cxx_levels)
+
+        # pop current values
+        list(POP_FRONT cxx_levels level)
+        list(POP_FRONT cxx_features feature)
+        list(POP_FRONT gcc_flags gcc_flag)
+        list(POP_FRONT cl_flags cl_flag)
+        list(POP_FRONT HAVE_CXX preprocessor_flag)
+
+        # check if we must enforce this one
+        if(enforced_level STREQUAL level)
+            set(force TRUE)
+        else()
+            set(force FALSE)
+        endif()
+
+        # check
+        get_set_stdcxx(${level} ${feature} ${gcc_flag} ${cl_flag} ${force} result)
+
+        if(result)
+            # we are done, mark all levels below as available 
+            set(${preprocessor_flag} 1 PARENT_SCOPE)
+            while(HAVE_CXX)
+                list(POP_FRONT HAVE_CXX preprocessor_flag)
+                set(${preprocessor_flag} 1 PARENT_SCOPE)
+            endwhile()
+            break()
+        else()
+            # If the user doesn't enforce this level the macros are not trustworthy
+            set(${preprocessor_flag} 0 PARENT_SCOPE)
+        endif()    
+
+    endwhile()    
+
+endfunction()
 
 macro(check_compile_feature)
     # Check constexpr

--- a/cmake/common/check_configuration.cmake
+++ b/cmake/common/check_configuration.cmake
@@ -132,10 +132,18 @@ macro(check_type_sizes)
 endmacro()
 
 macro(check_endianness)
-    # Test endianness
-    include(TestBigEndian)
-    test_big_endian(BIG_ENDIAN)
-    set(FASTCDR_IS_BIG_ENDIAN_TARGET ${BIG_ENDIAN})
+    if(CMAKE_CXX_BYTE_ORDER)
+        if(CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+            set(FASTCDR_IS_BIG_ENDIAN_TARGET 1)
+        else()
+            set(FASTCDR_IS_BIG_ENDIAN_TARGET 0)
+        endif()
+    else()
+        # Test endianness
+        include(TestBigEndian)
+        test_big_endian(BIG_ENDIAN)
+        set(FASTCDR_IS_BIG_ENDIAN_TARGET ${BIG_ENDIAN})
+    endif()
 endmacro()
 
 macro(check_msvc_arch)

--- a/cmake/common/check_configuration.cmake
+++ b/cmake/common/check_configuration.cmake
@@ -119,16 +119,6 @@ function(check_stdcxx enforced_level)
 
 endfunction()
 
-macro(check_compile_feature)
-    # Check constexpr
-    list(FIND CMAKE_CXX_COMPILE_FEATURES "cxx_constexpr" CXX_CONSTEXPR_SUPPORTED)
-    if(${CXX_CONSTEXPR_SUPPORTED} GREATER -1)
-        set(HAVE_CXX_CONSTEXPR 1)
-    else()
-        set(HAVE_CXX_CONSTEXPR 0)
-    endif()
-endmacro()
-
 macro(check_type_sizes)
     include(CheckTypeSize)
     check_type_size("long double" TYPE_LONG_DOUBLE)

--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -30,9 +30,7 @@
 #include <stdlib.h>
 #endif // if !__APPLE__ && !__FreeBSD__ && !__VXWORKS__
 
-#if HAVE_CXX0X
 #include <array>
-#endif // if HAVE_CXX0X
 
 namespace eprosima {
 namespace fastcdr {
@@ -55,11 +53,7 @@ public:
 
     //! @brief This enumeration represents the two posible values of the flag that points if the content is a parameter list (only in DDS CDR).
 
-#ifdef HAVE_CXX0X
     typedef enum : uint8_t
-#else
-    typedef enum
-#endif // ifdef HAVE_CXX0X
     {
         //! @brief Specifies that the content is not a parameter list.
         DDS_CDR_WITHOUT_PL = 0x0,
@@ -70,11 +64,7 @@ public:
     /*!
      * @brief This enumeration represents endianness types.
      */
-#ifdef HAVE_CXX0X
     typedef enum : uint8_t
-#else
-    typedef enum
-#endif // ifdef HAVE_CXX0X
     {
         //! @brief Big endianness.
         BIG_ENDIANNESS = 0x0,
@@ -488,7 +478,6 @@ public:
         return serialize(string_t);
     }
 
-#if HAVE_CXX0X
     /*!
      * @brief This operator template is used to serialize arrays.
      * @param array_t The array that will be serialized in the buffer.
@@ -501,8 +490,6 @@ public:
     {
         return serialize<_T, _Size>(array_t);
     }
-
-#endif // if HAVE_CXX0X
 
     /*!
      * @brief This operator template is used to serialize sequences.
@@ -753,7 +740,6 @@ public:
         return deserialize(string_t);
     }
 
-#if HAVE_CXX0X
     /*!
      * @brief This operator template is used to deserialize arrays.
      * @param array_t The variable that will store the array read from the buffer.
@@ -766,8 +752,6 @@ public:
     {
         return deserialize<_T, _Size>(array_t);
     }
-
-#endif // if HAVE_CXX0X
 
     /*!
      * @brief This operator template is used to deserialize sequences.
@@ -1243,7 +1227,6 @@ public:
         return serialize(string_t.c_str(), endianness);
     }
 
-#if HAVE_CXX0X
     /*!
      * @brief This function template serializes an array.
      * @param array_t The array that will be serialized in the buffer.
@@ -1272,9 +1255,6 @@ public:
         return serializeArray(array_t.data(), array_t.size(), endianness);
     }
 
-#endif // if HAVE_CXX0X
-
-#if !defined(_MSC_VER) && HAVE_CXX0X
     /*!
      * @brief This function template serializes a sequence of booleans.
      * @param vector_t The sequence that will be serialized in the buffer.
@@ -1287,8 +1267,6 @@ public:
     {
         return serializeBoolSequence(vector_t);
     }
-
-#endif // if !defined(_MSC_VER) && HAVE_CXX0X
 
     /*!
      * @brief This function template serializes a sequence.
@@ -2514,7 +2492,6 @@ public:
         return *this;
     }
 
-#if HAVE_CXX0X
     /*!
      * @brief This function template deserializes an array.
      * @param array_t The variable that will store the array read from the buffer.
@@ -2543,9 +2520,6 @@ public:
         return deserializeArray(array_t.data(), array_t.size(), endianness);
     }
 
-#endif // if HAVE_CXX0X
-
-#if !defined(_MSC_VER) && HAVE_CXX0X
     /*!
      * @brief This function template deserializes a sequence.
      * @param vector_t The variable that will store the sequence read from the buffer.
@@ -2558,8 +2532,6 @@ public:
     {
         return deserializeBoolSequence(vector_t);
     }
-
-#endif // if !defined(_MSC_VER) && HAVE_CXX0X
 
     /*!
      * @brief This function template deserializes a sequence.
@@ -3252,7 +3224,6 @@ public:
         return *this;
     }
 
-#if !defined(_MSC_VER) && HAVE_CXX0X
     /*!
      * @brief This function template deserializes a string sequence.
      * This function allocates memory to store the sequence. The user pointer will be set to point this allocated memory.
@@ -3286,8 +3257,6 @@ public:
     {
         return deserializeWStringSequence(sequence_t, numElements);
     }
-
-#endif // if !defined(_MSC_VER) && HAVE_CXX0X
 
     /*!
      * @brief This function template deserializes a raw sequence.
@@ -3417,7 +3386,6 @@ private:
             std::wstring*& sequence_t,
             size_t& numElements);
 
-#if HAVE_CXX0X
     /*!
      * @brief This function template detects the content type of the STD container array and serializes the array.
      * @param array_t The array that will be serialized in the buffer.
@@ -3481,8 +3449,6 @@ private:
     {
         return deserializeArray(array_t->data(), numElements * array_t->size(), endianness);
     }
-
-#endif // if HAVE_CXX0X
 
     /*!
      * @brief This function returns the extra bytes regarding the allignment.

--- a/include/fastcdr/FastCdr.h
+++ b/include/fastcdr/FastCdr.h
@@ -28,9 +28,7 @@
 #include <stdlib.h>
 #endif // if !__APPLE__ && !__FreeBSD__ && !__VXWORKS__
 
-#if HAVE_CXX0X
 #include <array>
-#endif // if HAVE_CXX0X
 
 namespace eprosima {
 namespace fastcdr {
@@ -338,7 +336,6 @@ public:
         return serialize(string_t);
     }
 
-#if HAVE_CXX0X
     /*!
      * @brief This operator template is used to serialize arrays.
      * @param array_t The array that will be serialized in the buffer.
@@ -351,8 +348,6 @@ public:
     {
         return serialize<_T, _Size>(array_t);
     }
-
-#endif // if HAVE_CXX0X
 
     /*!
      * @brief This operator template is used to serialize sequences.
@@ -589,7 +584,6 @@ public:
         return deserialize(string_t);
     }
 
-#if HAVE_CXX0X
     /*!
      * @brief This operator template is used to deserialize arrays.
      * @param array_t The variable that will store the array read from the buffer.
@@ -602,8 +596,6 @@ public:
     {
         return deserialize<_T, _Size>(array_t);
     }
-
-#endif // if HAVE_CXX0X
 
     /*!
      * @brief This operator template is used to deserialize sequences.
@@ -912,7 +904,6 @@ public:
         return serialize(string_t.c_str());
     }
 
-#if HAVE_CXX0X
     /*!
      * @brief This function template serializes an array.
      * @param array_t The array that will be serialized in the buffer.
@@ -926,9 +917,6 @@ public:
         return serializeArray(array_t.data(), array_t.size());
     }
 
-#endif // if HAVE_CXX0X
-
-#if !defined(_MSC_VER) && HAVE_CXX0X
     /*!
      * @brief This function template serializes a sequence of booleans.
      * @param vector_t The sequence that will be serialized in the buffer.
@@ -941,8 +929,6 @@ public:
     {
         return serializeBoolSequence(vector_t);
     }
-
-#endif // if !defined(_MSC_VER) && HAVE_CXX0X
 
     /*!
      * @brief This function template serializes a sequence.
@@ -1574,7 +1560,6 @@ public:
         return *this;
     }
 
-#if HAVE_CXX0X
     /*!
      * @brief This function template deserializes an array.
      * @param array_t The variable that will store the array read from the buffer.
@@ -1588,9 +1573,6 @@ public:
         return deserializeArray(array_t.data(), array_t.size());
     }
 
-#endif // if HAVE_CXX0X
-
-#if !defined(_MSC_VER) && HAVE_CXX0X
     /*!
      * @brief This function template deserializes a sequence of booleans.
      * @param vector_t The variable that will store the sequence read from the buffer.
@@ -1603,8 +1585,6 @@ public:
     {
         return deserializeBoolSequence(vector_t);
     }
-
-#endif // if !defined(_MSC_VER) && HAVE_CXX0X
 
     /*!
      * @brief This function template deserializes a sequence.
@@ -1915,7 +1895,6 @@ public:
         return *this;
     }
 
-#if !defined(_MSC_VER) && HAVE_CXX0X
     /*!
      * @brief This function template deserializes a string sequence.
      * This function allocates memory to store the sequence. The user pointer will be set to point this allocated memory.
@@ -1949,8 +1928,6 @@ public:
     {
         return deserializeWStringSequence(sequence_t, numElements);
     }
-
-#endif // if !defined(_MSC_VER) && HAVE_CXX0X
 
     /*!
      * @brief This function template deserializes a raw sequence.
@@ -2047,7 +2024,6 @@ private:
             std::wstring*& sequence_t,
             size_t& numElements);
 
-#if HAVE_CXX0X
     /*!
      * @brief This function template detects the content type of the STD container array and serializes the array.
      * @param array_t The array that will be serialized in the buffer.
@@ -2077,8 +2053,6 @@ private:
     {
         return deserializeArray(array_t->data(), numElements * array_t->size());
     }
-
-#endif // if HAVE_CXX0X
 
     bool resize(
             size_t minSizeInc);

--- a/include/fastcdr/config.h.in
+++ b/include/fastcdr/config.h.in
@@ -25,17 +25,6 @@
 #define HAVE_CXX11 @HAVE_CXX11@
 #endif
 
-// C++ constexpr support
-#ifndef HAVE_CXX_CONSTEXPR
-#define HAVE_CXX_CONSTEXPR @HAVE_CXX_CONSTEXPR@
-#endif
-
-#if HAVE_CXX_CONSTEXPR
-#define CONSTEXPR constexpr
-#else
-#define CONSTEXPR const
-#endif
-
 // Endianness defines
 #ifndef FASTCDR_IS_BIG_ENDIAN_TARGET
 #define FASTCDR_IS_BIG_ENDIAN_TARGET @FASTCDR_IS_BIG_ENDIAN_TARGET@

--- a/include/fastcdr/config.h.in
+++ b/include/fastcdr/config.h.in
@@ -25,11 +25,6 @@
 #define HAVE_CXX11 @HAVE_CXX11@
 #endif
 
-// C++0x support defines
-#ifndef HAVE_CXX0X
-#define HAVE_CXX0X @HAVE_CXX0X@
-#endif
-
 // C++ constexpr support
 #ifndef HAVE_CXX_CONSTEXPR
 #define HAVE_CXX_CONSTEXPR @HAVE_CXX_CONSTEXPR@

--- a/include/fastcdr/exceptions/BadParamException.h
+++ b/include/fastcdr/exceptions/BadParamException.h
@@ -44,7 +44,6 @@ public:
     Cdr_DllAPI BadParamException(
             const BadParamException& ex) noexcept;
 
-#if HAVE_CXX0X
     /*!
      * @brief Default move constructor.
      *
@@ -52,7 +51,6 @@ public:
      */
     Cdr_DllAPI BadParamException(
             BadParamException&& ex) noexcept;
-#endif // if HAVE_CXX0X
 
     /*!
      * @brief Assigment operation.
@@ -62,7 +60,6 @@ public:
     Cdr_DllAPI BadParamException& operator =(
             const BadParamException& ex) noexcept;
 
-#if HAVE_CXX0X
     /*!
      * @brief Assigment operation.
      *
@@ -70,7 +67,6 @@ public:
      */
     BadParamException& operator =(
             BadParamException&& ex) noexcept;
-#endif // if HAVE_CXX0X
 
     //! @brief Default constructor
     virtual Cdr_DllAPI ~BadParamException() noexcept;

--- a/include/fastcdr/exceptions/Exception.h
+++ b/include/fastcdr/exceptions/Exception.h
@@ -61,7 +61,6 @@ protected:
     Cdr_DllAPI Exception(
             const Exception& ex) noexcept;
 
-#if HAVE_CXX0X
     /*!
      * @brief Default move constructor.
      *
@@ -69,7 +68,6 @@ protected:
      */
     Cdr_DllAPI Exception(
             Exception&& ex) noexcept;
-#endif // if HAVE_CXX0X
 
     /*!
      * @brief Assigment operation.
@@ -79,7 +77,6 @@ protected:
     Cdr_DllAPI Exception& operator =(
             const Exception& ex) noexcept;
 
-#if HAVE_CXX0X
     /*!
      * @brief Assigment operation.
      *
@@ -87,7 +84,6 @@ protected:
      */
     Cdr_DllAPI Exception& operator =(
             Exception&&) noexcept;
-#endif // if HAVE_CXX0X
 
 private:
 

--- a/include/fastcdr/exceptions/NotEnoughMemoryException.h
+++ b/include/fastcdr/exceptions/NotEnoughMemoryException.h
@@ -44,7 +44,6 @@ public:
     Cdr_DllAPI NotEnoughMemoryException(
             const NotEnoughMemoryException& ex) noexcept;
 
-#if HAVE_CXX0X
     /*!
      * @brief Default move constructor.
      *
@@ -52,7 +51,6 @@ public:
      */
     Cdr_DllAPI NotEnoughMemoryException(
             NotEnoughMemoryException&& ex) noexcept;
-#endif // if HAVE_CXX0X
 
     /*!
      * @brief Assigment operation.
@@ -62,7 +60,6 @@ public:
     Cdr_DllAPI NotEnoughMemoryException& operator =(
             const NotEnoughMemoryException& ex) noexcept;
 
-#if HAVE_CXX0X
     /*!
      * @brief Assigment operation.
      *
@@ -70,7 +67,6 @@ public:
      */
     Cdr_DllAPI NotEnoughMemoryException& operator =(
             NotEnoughMemoryException&& ex) noexcept;
-#endif // if HAVE_CXX0X
 
     //! @brief Default constructor
     virtual Cdr_DllAPI ~NotEnoughMemoryException() noexcept;

--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -24,7 +24,7 @@ const Cdr::Endianness Cdr::DEFAULT_ENDIAN = BIG_ENDIANNESS;
 const Cdr::Endianness Cdr::DEFAULT_ENDIAN = LITTLE_ENDIANNESS;
 #endif // if FASTCDR_IS_BIG_ENDIAN_TARGET
 
-CONSTEXPR size_t ALIGNMENT_LONG_DOUBLE = 8;
+constexpr size_t ALIGNMENT_LONG_DOUBLE = 8;
 
 Cdr::state::state(
         const Cdr& cdr)

--- a/src/cpp/exceptions/BadParamException.cpp
+++ b/src/cpp/exceptions/BadParamException.cpp
@@ -30,14 +30,11 @@ BadParamException::BadParamException(
 {
 }
 
-#if HAVE_CXX0X
 BadParamException::BadParamException(
         BadParamException&& ex) noexcept
     : Exception(std::move(ex))
 {
 }
-
-#endif // if HAVE_CXX0X
 
 BadParamException& BadParamException::operator =(
         const BadParamException& ex) noexcept
@@ -51,7 +48,6 @@ BadParamException& BadParamException::operator =(
     return *this;
 }
 
-#if HAVE_CXX0X
 BadParamException& BadParamException::operator =(
         BadParamException&& ex) noexcept
 {
@@ -63,8 +59,6 @@ BadParamException& BadParamException::operator =(
 
     return *this;
 }
-
-#endif // if HAVE_CXX0X
 
 BadParamException::~BadParamException() noexcept
 {

--- a/src/cpp/exceptions/Exception.cpp
+++ b/src/cpp/exceptions/Exception.cpp
@@ -28,14 +28,11 @@ Exception::Exception(
 {
 }
 
-#if HAVE_CXX0X
 Exception::Exception(
         Exception&& ex) noexcept
     : m_message(std::move(ex.m_message))
 {
 }
-
-#endif // if HAVE_CXX0X
 
 Exception& Exception::operator =(
         const Exception& ex) noexcept
@@ -44,15 +41,12 @@ Exception& Exception::operator =(
     return *this;
 }
 
-#if HAVE_CXX0X
 Exception& Exception::operator =(
         Exception&& ex) noexcept
 {
     m_message = std::move(ex.m_message);
     return *this;
 }
-
-#endif // if HAVE_CXX0X
 
 Exception::~Exception() noexcept
 {

--- a/src/cpp/exceptions/NotEnoughMemoryException.cpp
+++ b/src/cpp/exceptions/NotEnoughMemoryException.cpp
@@ -31,14 +31,11 @@ NotEnoughMemoryException::NotEnoughMemoryException(
 {
 }
 
-#if HAVE_CXX0X
 NotEnoughMemoryException::NotEnoughMemoryException(
         NotEnoughMemoryException&& ex) noexcept
     : Exception(std::move(ex))
 {
 }
-
-#endif // if HAVE_CXX0X
 
 NotEnoughMemoryException& NotEnoughMemoryException::operator =(
         const NotEnoughMemoryException& ex) noexcept
@@ -52,7 +49,6 @@ NotEnoughMemoryException& NotEnoughMemoryException::operator =(
     return *this;
 }
 
-#if HAVE_CXX0X
 NotEnoughMemoryException& NotEnoughMemoryException::operator =(
         NotEnoughMemoryException&& ex) noexcept
 {
@@ -64,8 +60,6 @@ NotEnoughMemoryException& NotEnoughMemoryException::operator =(
 
     return *this;
 }
-
-#endif // if HAVE_CXX0X
 
 NotEnoughMemoryException::~NotEnoughMemoryException() noexcept
 {


### PR DESCRIPTION
This pull request relates to https://github.com/eProsima/Fast-DDS/pull/2579.
Upgrades the minimum CMake requirement to 3.16.3 (Ubuntu Focal).
Enforces C++11 used in order to align with Fast-DDS.
Upgrades the fashion CMake deals with C++ standards using:
 + CMake detection and setting of the supported standards.
 + Complete Backwards compatibility
All preprocessor workarounds to address non C++11 availability have been removed too.