### PR TITLE
Fix: serialization terminating on Null characters

### DIFF
--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -1172,6 +1172,17 @@ public:
             const char* string_t);
 
     /*!
+     * @brief This function serializes a string.
+     * @param string_t The pointer to the string that will be serialized in the buffer.
+     * @param length Length of input string.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr& serialize(
+            const char *string_t,
+            size_t length);
+
+    /*!
      * @brief This function serializes a wstring.
      * @param string_t The pointer to the wstring that will be serialized in the buffer.
      * @return Reference to the eprosima::fastcdr::Cdr object.
@@ -1189,6 +1200,19 @@ public:
      */
     Cdr& serialize(
             const char* string_t,
+            Endianness endianness);
+
+    /*!
+     * @brief This function serializes a string with a different endianness and predefined size.
+     * @param string_t The pointer to the string that will be serialized in the buffer.
+     * @param length Length of input string.
+     * @param endianness Endianness that will be used in the serialization of this value.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to serialize a position that exceeds the internal memory size.
+     */
+    Cdr& serialize(
+            const char *string_t,
+            size_t length,
             Endianness endianness);
 
     /*!
@@ -1212,7 +1236,7 @@ public:
     Cdr& serialize(
             const std::string& string_t)
     {
-        return serialize(string_t.c_str());
+        return serialize(string_t.c_str(), string_t.size());
     }
 
     /*!
@@ -1240,7 +1264,7 @@ public:
             const std::string& string_t,
             Endianness endianness)
     {
-        return serialize(string_t.c_str(), endianness);
+        return serialize(string_t.c_str(), string_t.size(), endianness);
     }
 
 #if HAVE_CXX0X

--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -741,6 +741,40 @@ Cdr& Cdr::serialize(
 }
 
 Cdr& Cdr::serialize(
+        const char *string_t,
+        size_t str_length)
+{
+    uint32_t length = 0;
+
+    if(string_t != nullptr)
+        length = (uint32_t)str_length + 1;
+
+    if(length > 0)
+    {
+        Cdr::state state(*this);
+        serialize(length);
+
+        if(((m_lastPosition - m_currentPosition) >= length) || resize(length))
+        {
+            // Save last datasize.
+            m_lastDataSize = sizeof(uint8_t);
+
+            m_currentPosition.memcopy(string_t, length);
+            m_currentPosition += length;
+        }
+        else
+        {
+            setState(state);
+            throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        }
+    }
+    else
+        serialize(length);
+
+    return *this;
+}
+
+Cdr& Cdr::serialize(
         const wchar_t* string_t)
 {
     uint32_t bytesLength = 0;
@@ -796,6 +830,27 @@ Cdr& Cdr::serialize(
         m_swapBytes = auxSwap;
     }
     catch (Exception& ex)
+    {
+        m_swapBytes = auxSwap;
+        ex.raise();
+    }
+
+    return *this;
+}
+
+Cdr& Cdr::serialize(const char *string_t,
+        size_t length,
+        Endianness endianness)
+{
+    bool auxSwap = m_swapBytes;
+    m_swapBytes = (m_swapBytes && (m_endianness == endianness)) || (!m_swapBytes && (m_endianness != endianness));
+
+    try
+    {
+        serialize(string_t, length);
+        m_swapBytes = auxSwap;
+    }
+    catch(Exception &ex)
     {
         m_swapBytes = auxSwap;
         ex.raise();


### PR DESCRIPTION
In serialize functions strlen is used. That makes impossible to serialize protobuf with null character in the messages. I propose to add function serialize(const char* string_t, int len).