### PR TITLE
[15485] Fix SerializeArray error when swaping the bytes

### DIFF
--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -765,8 +765,24 @@ Cdr& Cdr::serialize(
 #if defined(_WIN32)
             serializeArray(string_t, wstrlen);
 #else
-            m_currentPosition.memcopy(string_t, bytesLength);
-            m_currentPosition += bytesLength; // size on bytes
+            if (m_swapBytes)
+            {
+                const char* dst = reinterpret_cast<const char*>(string_t);
+                const char* end = dst + bytesLength;
+
+                for (; dst < end; dst += sizeof(*string_t))
+                {
+                    m_currentPosition++ << dst[3];
+                    m_currentPosition++ << dst[2];
+                    m_currentPosition++ << dst[1];
+                    m_currentPosition++ << dst[0];
+                }
+            }
+            else
+            {
+                m_currentPosition.memcopy(string_t, bytesLength);
+                m_currentPosition += bytesLength; // size on bytes
+            }
 #endif // if defined(_WIN32)
         }
         else

--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -898,7 +898,7 @@ Cdr& Cdr::serializeArray(
 
         if (m_swapBytes)
         {
-            const char* dst = reinterpret_cast<const char*>(&short_t);
+            const char* dst = reinterpret_cast<const char*>(short_t);
             const char* end = dst + totalSize;
 
             for (; dst < end; dst += sizeof(*short_t))
@@ -967,7 +967,7 @@ Cdr& Cdr::serializeArray(
 
         if (m_swapBytes)
         {
-            const char* dst = reinterpret_cast<const char*>(&long_t);
+            const char* dst = reinterpret_cast<const char*>(long_t);
             const char* end = dst + totalSize;
 
             for (; dst < end; dst += sizeof(*long_t))
@@ -1076,7 +1076,7 @@ Cdr& Cdr::serializeArray(
 
         if (m_swapBytes)
         {
-            const char* dst = reinterpret_cast<const char*>(&longlong_t);
+            const char* dst = reinterpret_cast<const char*>(longlong_t);
             const char* end = dst + totalSize;
 
             for (; dst < end; dst += sizeof(*longlong_t))
@@ -1151,7 +1151,7 @@ Cdr& Cdr::serializeArray(
 
         if (m_swapBytes)
         {
-            const char* dst = reinterpret_cast<const char*>(&float_t);
+            const char* dst = reinterpret_cast<const char*>(float_t);
             const char* end = dst + totalSize;
 
             for (; dst < end; dst += sizeof(*float_t))
@@ -1222,7 +1222,7 @@ Cdr& Cdr::serializeArray(
 
         if (m_swapBytes)
         {
-            const char* dst = reinterpret_cast<const char*>(&double_t);
+            const char* dst = reinterpret_cast<const char*>(double_t);
             const char* end = dst + totalSize;
 
             for (; dst < end; dst += sizeof(*double_t))
@@ -1334,7 +1334,7 @@ Cdr& Cdr::serializeArray(
 #if FASTCDR_SIZEOF_LONG_DOUBLE == 8 || FASTCDR_SIZEOF_LONG_DOUBLE == 16
         if (m_swapBytes)
         {
-            const char* dst = reinterpret_cast<const char*>(&ldouble_t);
+            const char* dst = reinterpret_cast<const char*>(ldouble_t);
             const char* end = dst + totalSize;
 
             for (; dst < end; dst += sizeof(*ldouble_t))

--- a/test/SimpleTest.cpp
+++ b/test/SimpleTest.cpp
@@ -241,14 +241,31 @@ static void check_good_case(
     // Serialization.
     {
         FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
-        Cdr cdr_ser(cdrbuffer);
+        Cdr cdr_ser(cdrbuffer, eprosima::fastcdr::Cdr::Endianness::LITTLE_ENDIANNESS);
         EXPECT_NO_THROW(cdr_ser << input_value);
     }
 
     // Deserialization.
     {
         FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
-        Cdr cdr_des(cdrbuffer);
+        Cdr cdr_des(cdrbuffer, eprosima::fastcdr::Cdr::Endianness::LITTLE_ENDIANNESS);
+        T output_value{};
+
+        EXPECT_NO_THROW(cdr_des >> output_value);
+        EXPECT_EQ(output_value, input_value);
+    }
+
+    // Serialization.
+    {
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_ser(cdrbuffer, eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_ser << input_value);
+    }
+
+    // Deserialization.
+    {
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_des(cdrbuffer, eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
         T output_value{};
 
         EXPECT_NO_THROW(cdr_des >> output_value);
@@ -291,14 +308,30 @@ static void check_good_case_array(
     // Serialization.
     {
         FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
-        Cdr cdr_ser(cdrbuffer);
+        Cdr cdr_ser(cdrbuffer, eprosima::fastcdr::Cdr::Endianness::LITTLE_ENDIANNESS);
         EXPECT_NO_THROW(cdr_ser.serializeArray(input_value, N));
     }
 
     // Deserialization.
     {
         FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
-        Cdr cdr_des(cdrbuffer);
+        Cdr cdr_des(cdrbuffer, eprosima::fastcdr::Cdr::Endianness::LITTLE_ENDIANNESS);
+        T output_value[N];
+
+        EXPECT_NO_THROW(cdr_des.deserializeArray(output_value, N));
+        EXPECT_ARRAY_EQ(output_value, input_value, N);
+    }
+    // Serialization.
+    {
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_ser(cdrbuffer, eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_ser.serializeArray(input_value, N));
+    }
+
+    // Deserialization.
+    {
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_des(cdrbuffer, eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
         T output_value[N];
 
         EXPECT_NO_THROW(cdr_des.deserializeArray(output_value, N));


### PR DESCRIPTION
In SerializeArray Function, the '&' operator was used to a pointer.