### PR TITLE
Increase cmake minimum required [16413]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 ###############################################################################
 # CMake build rules for FastCDR                                               #
 ###############################################################################
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.15)
 
 set(IS_TOP_LEVEL TRUE)
 if(PROJECT_SOURCE_DIR)


### PR DESCRIPTION
Visual Studio 19 is supported since CMake 3.14. But with this version, this project has a CMake warning. It is a bug fixed in CMake 3.15.5. Then I've increased the minimum required to 3.15 and our CI is testing against this version.