### PR TITLE
Support ccache on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,19 @@ message(STATUS "To change the version modify the file configure.ac")
 option(EPROSIMA_INSTALLER "Activate the creation of a build to create windows installers" OFF)
 
 ###############################################################################
+# CCache on Windows on CI
+###############################################################################
+if (MSVC AND CMAKE_CXX_COMPILER_LAUNCHER STREQUAL "ccache")
+    foreach(config DEBUG RELWITHDEBINFO)
+        foreach(lang C CXX)
+            set(flags_var "CMAKE_${lang}_FLAGS_${config}")
+            string(REPLACE "/Zi" "/Z7" ${flags_var} "${${flags_var}}")
+            set(${flags_var} "${${flags_var}}")
+        endforeach()
+    endforeach()
+endif()
+
+###############################################################################
 # GCC colors if using CCache
 ###############################################################################
 if("${CMAKE_CXX_COMPILER_LAUNCHER}" STREQUAL "ccache" AND


### PR DESCRIPTION
Since CCache 4.6.1, Visual Studio is supported. But for Debug and RelWithDebugInfo build types, `ccache` needs the compilation option `Z7` instead of `Zi`. This PR adds the CMake feature of detecting the usage of `ccache` and changing the compilation option.