### PR TITLE
[18926] Allow user to override stream operators

### DIFF
--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -1910,7 +1910,7 @@ public:
     {
         for (size_t count = 0; count < numElements; ++count)
         {
-            type_t[count].serialize(*this);
+            *this << type_t[count];
         }
         return *this;
     }
@@ -3198,7 +3198,7 @@ public:
     {
         for (size_t count = 0; count < numElements; ++count)
         {
-            type_t[count].deserialize(*this);
+            *this >> type_t[count];
         }
         return *this;
     }


### PR DESCRIPTION
The changes in this PR allow users to create their own overload of the `<<` and `>>` operators for a data type, and they will be automagically used for vectors and arrays.