### PR TITLE
[19461] Fix Fast CDR API reference PDF generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,7 @@ endif()
 # Add an option to toggle the generation of the API documentation.
 option(BUILD_DOCUMENTATION "Use doxygen to create product documentation" OFF)
 option(CHECK_DOCUMENTATION "Use doxygen to check code documentation" OFF)
+option(GENERATE_PDF_DOC "Use doxygen to generate API Reference PDF" OFF)
 
 if(CHECK_DOCUMENTATION)
     set(BUILD_DOCUMENTATION ON)
@@ -188,6 +189,11 @@ if(BUILD_DOCUMENTATION)
     else()
         set(USE_DOT YES)
     endif()
+    if(GENERATE_PDF_DOC)
+        set(GENERATE_LATEX YES)
+    else()
+        set(GENERATE_LATEX NO)
+    endif()
     # Configure the template doxyfile for or specific project
     configure_file(doxyfile.in ${PROJECT_BINARY_DIR}/doxyfile @ONLY IMMEDIATE)
     # Add custom target to run doxygen when ever the project is build
@@ -197,6 +203,15 @@ if(BUILD_DOCUMENTATION)
         COMMENT "Generating API documentation with doxygen" VERBATIM)
 
     add_dependencies(doxygen docdirs)
+
+    if(GENERATE_PDF_DOC)
+        add_custom_target(make_pdf ALL
+            COMMAND "make" "pdf"
+            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/doxygen/latex
+            COMMENT "Generating API reference PDF" VERBATIM)
+
+        add_dependencies(make_pdf doxygen)
+    endif()
 
     ### README html ########################
 
@@ -239,4 +254,11 @@ if(BUILD_DOCUMENTATION)
         DESTINATION ${README_INSTALL_LOCATION}
         COMPONENT documentation
         )
+
+    if(GENERATE_PDF_DOC)
+        install(FILES "${PROJECT_BINARY_DIR}/doxygen/latex/refman.pdf"
+        DESTINATION ${DOC_INSTALL_DIR}
+        RENAME fastcdr-${PROJECT_VERSION}-api-reference.pdf
+        COMPONENT documentation)
+    endif()
 endif()

--- a/doxyfile.in
+++ b/doxyfile.in
@@ -958,8 +958,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */fastdds/* \
-                         */dds/*
+EXCLUDE_PATTERNS       =
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the
@@ -1782,7 +1781,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = NO
+GENERATE_LATEX         = @GENERATE_LATEX@
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of


### PR DESCRIPTION
This PR adds a new CMake option `GENERATE_PDF_DOC` to configure the doxyfile in order to generate the intermediate files required to generate the API reference in PDF format. This PR also includes the required changes in the CMakeLists.txt to properly generate and install this document.