### PR TITLE
fix for non CWG 1270 revision compliant compilers (e.g. QNX qcc 5.4)

### DIFF
--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -3263,7 +3263,7 @@ private:
     EncodingAlgorithmFlag current_encoding_ {EncodingAlgorithmFlag::PLAIN_CDR2};
 
     //! @brief This attribute stores the option flags when the CDR type is DDS_CDR;
-    std::array<uint8_t, 2> options_ {0};
+    std::array<uint8_t, 2> options_{{0}};
 
     //! @brief The endianness that will be applied over the buffer.
     uint8_t endianness_ {Endianness::LITTLE_ENDIANNESS};


### PR DESCRIPTION
as described in cppreference (https://en.cppreference.com/w/cpp/container/array) prior to CWG 1270 revision std::array was required to be initialized using double braces, the QNX SDP 7.0's qcc 5.4 is one of these compilers and compilation errors arise without this patch.

Signed-off-by: Utkan Kılıç utkankilic@gmail.com