### PR TITLE
[19902] Bump version to 2.1.0

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,22 @@
+# .github/workflows/mirror.yml
+on:
+  push:
+    branches:
+      - 'master'
+jobs:
+  mirror_job:
+    runs-on: ubuntu-latest
+    name: Mirror master branch to API & ABI compatible minor version branches
+    strategy:
+      fail-fast: false
+      matrix:
+        dest_branch:
+          - '2.1.x'
+    steps:
+    - name: Mirror action step
+      id: mirror
+      uses: eProsima/eProsima-CI/external/mirror-branch-action@v0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        source: 'master'
+        dest: ${{ matrix.dest_branch }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 ###############################################################################
 # Project                                                                     #
 ###############################################################################
-project(fastcdr VERSION 2.0.0 LANGUAGES CXX)
+project(fastcdr VERSION 2.1.0 LANGUAGES CXX)
 
 set(PROJECT_NAME_STYLED "FastCDR")
 set(PROJECT_NAME_LARGE "Fast CDR")


### PR DESCRIPTION
This PR

1. Bumps the project version to 2.1.0
2. Adds a mirror workflow so that the latest version branch is kept up to date with master.
   This is necessary to transition to a branching model similar to Fast DDS', where master is kept as a development branch, and each minor version has a corresponding X.Y.x branch so we can handle backports and releases in a more consistent manner.