### PR TITLE
[20176] Downgrade cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 ###############################################################################
 # CMake build rules for FastCDR                                               #
 ###############################################################################
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.20)
 
 # Set CMAKE_BUILD_TYPE to Release by default.
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/test/cmake/CMakeLists.txt
+++ b/test/cmake/CMakeLists.txt
@@ -15,7 +15,7 @@
 ###############################################################################
 # Auxiliary project for check_configuration.cmake module testing
 ###############################################################################
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.20)
 
 # setup
 option(TEST_FALLBACK "Ignore CMake builtin instrospection and use our original fallback" OFF)


### PR DESCRIPTION
Reduce CMake minimum version required for Fast DDS compatibility against RHEL 9.