### PR TITLE
Regression test for #185 in SimpleTest

### DIFF
--- a/test/cdr/SimpleTest.cpp
+++ b/test/cdr/SimpleTest.cpp
@@ -1900,6 +1900,32 @@ TEST(CDRTests, CWString)
 
     free(c_string_value);
 
+    // Check the big endianness case
+    char buffer_bigendi[BUFFER_LENGTH];
+
+    // Serialization.
+    FastBuffer cdrbuffer_bigendi(buffer_bigendi, BUFFER_LENGTH);
+    Cdr cdr_ser_bigendi(cdrbuffer_bigendi, eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
+
+    EXPECT_NO_THROW(
+    {
+        cdr_ser_bigendi.serialize(c_wstring_t);
+    });
+
+    // Deserialization.
+    Cdr cdr_des_bigendi(cdrbuffer_bigendi, eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
+
+    wchar_t* c_string_bigendi = NULL;
+
+    EXPECT_NO_THROW(
+    {
+        cdr_des_bigendi.deserialize(c_string_bigendi);
+    });
+
+    EXPECT_EQ(wcscmp(c_string_bigendi, c_wstring_t), 0);
+
+    free(c_string_bigendi);
+
     // Check bad case without space
     char buffer_bad[1];
 


### PR DESCRIPTION
This is a regression test case added to SimpleTest in the `TEST(CDRTests, CWString)` test case.
The build and test methodology is executed in the following steps.
```
git clone https://github.com/eProsima/Fast-CDR.git

cd Fast-CDR

mkdir build && cd build

cmake .. -DCMAKE_INSTALL_PREFIX=../install -D BUILD_TESTING=ON -D GTest_DIR=/usr/local

cmake --build . --target install

./test/cdr/UnitTests 
```