### PR TITLE
Support serializing a std::vector as an array.

### DIFF
--- a/fastcdr.repos
+++ b/fastcdr.repos
@@ -3,3 +3,7 @@ repositories:
         type: git
         url: https://github.com/eProsima/Fast-CDR.git
         version: master
+    googletest-distribution:
+        type: git
+        url: https://github.com/google/googletest.git
+        version: release-1.11.0

--- a/fastcdr.repos
+++ b/fastcdr.repos
@@ -3,7 +3,3 @@ repositories:
         type: git
         url: https://github.com/eProsima/Fast-CDR.git
         version: master
-    googletest-distribution:
-        type: git
-        url: https://github.com/google/googletest.git
-        version: release-1.11.0

--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -3012,6 +3012,22 @@ public:
         return *this;
     }
 
+    void set_serialized_member_size()
+    {
+        serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
+    }
+
+    /*!
+     * @brief This function returns the extra bytes regarding the allignment.
+     * @param data_size The size of the data that will be serialized.
+     * @return The size needed for the alignment.
+     */
+    inline size_t alignment(
+            size_t data_size) const
+    {
+        return data_size > last_data_size_ ? (data_size - ((offset_ - origin_) % data_size)) & (data_size - 1) : 0;
+    }
+
 private:
 
     Cdr(
@@ -3085,17 +3101,6 @@ private:
             Endianness endianness)
     {
         return deserialize_array(array_t->data(), num_elements * array_t->size(), endianness);
-    }
-
-    /*!
-     * @brief This function returns the extra bytes regarding the allignment.
-     * @param data_size The size of the data that will be serialized.
-     * @return The size needed for the alignment.
-     */
-    inline size_t alignment(
-            size_t data_size) const
-    {
-        return data_size > last_data_size_ ? (data_size - ((offset_ - origin_) % data_size)) & (data_size - 1) : 0;
     }
 
     /*!

--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -2944,7 +2944,7 @@ public:
      * After serializing the members's type, @ref set_xcdrv2_dheader must be called to set the correct DHEADER value
      * using the @ref state returned by this function.
      */
-    state allocate_xcdrv2_dheader();
+    Cdr_DllAPI state allocate_xcdrv2_dheader();
 
     /*!
      * @brief Uses the @ref state to calculate the member's type size and serialize the value in the previous allocated
@@ -2952,7 +2952,7 @@ public:
      *
      * @param[in] state @ref state used to calculate the member's type size.
      */
-    void set_xcdrv2_dheader(
+    Cdr_DllAPI void set_xcdrv2_dheader(
             const state& state);
 
 private:

--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -266,7 +266,7 @@ public:
     Cdr_DllAPI size_t get_serialized_data_length() const;
 
     /*!
-     * @brief Get the number of bytes needed to align a position to certain data size.
+     * @brief Returns the number of bytes needed to align a position to certain data size.
      * @param current_alignment Position to be aligned.
      * @param data_size Size of next data to process (should be power of two).
      * @return Number of required alignment bytes.
@@ -748,26 +748,17 @@ public:
     Cdr& serialize(
             const std::array<_T, _Size>& array_t)
     {
-        Cdr::state dheader_state(*this);
-
-        if (CdrVersion::XCDRv2 == cdr_version_ && !is_multi_array_primitive(&array_t))
+        if (!is_multi_array_primitive(&array_t))
         {
-            // Serialize DHEADER
-            uint32_t dheader {0};
-            serialize(dheader);
+            Cdr::state dheader_state {allocate_xcdrv2_dheader()};
+
+            serialize_array(array_t.data(), array_t.size());
+
+            set_xcdrv2_dheader(dheader_state);
         }
-
-        serialize_array(array_t.data(), array_t.size());
-
-        if (CdrVersion::XCDRv2 == cdr_version_ && !is_multi_array_primitive(&array_t))
+        else
         {
-            auto offset = offset_;
-            Cdr::state state_after(*this);
-            set_state(dheader_state);
-            size_t dheader = offset - offset_ - (4 + alignment(sizeof(uint32_t)));/* DHEADER */
-            serialize(static_cast<uint32_t>(dheader));
-            set_state(state_after);
-            serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
+            serialize_array(array_t.data(), array_t.size());
         }
 
         return *this;
@@ -784,14 +775,7 @@ public:
     Cdr& serialize(
             const std::vector<_T>& vector_t)
     {
-        Cdr::state dheader_state(*this);
-
-        if (CdrVersion::XCDRv2 == cdr_version_)
-        {
-            // Serialize DHEADER
-            uint32_t dheader {0};
-            serialize(dheader);
-        }
+        Cdr::state dheader_state {allocate_xcdrv2_dheader()};
 
         serialize(static_cast<int32_t>(vector_t.size()));
 
@@ -805,16 +789,7 @@ public:
             ex.raise();
         }
 
-        if (CdrVersion::XCDRv2 == cdr_version_)
-        {
-            auto offset = offset_;
-            Cdr::state state_after(*this);
-            set_state(dheader_state);
-            size_t dheader = offset - offset_ - (4 + alignment(sizeof(uint32_t)));/* DHEADER */
-            serialize(static_cast<uint32_t>(dheader));
-            set_state(state_after);
-            serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
-        }
+        set_xcdrv2_dheader(dheader_state);
 
         return *this;
     }
@@ -876,14 +851,7 @@ public:
     Cdr& serialize(
             const std::map<_K, _T>& map_t)
     {
-        Cdr::state dheader_state(*this);
-
-        if (CdrVersion::XCDRv2 == cdr_version_)
-        {
-            // Serialize DHEADER
-            uint32_t dheader {0};
-            serialize(dheader);
-        }
+        Cdr::state dheader_state {allocate_xcdrv2_dheader()};
 
         serialize(static_cast<int32_t>(map_t.size()));
 
@@ -901,16 +869,7 @@ public:
             ex.raise();
         }
 
-        if (CdrVersion::XCDRv2 == cdr_version_)
-        {
-            auto offset = offset_;
-            Cdr::state state_after(*this);
-            set_state(dheader_state);
-            size_t dheader = offset - offset_ - (4 + alignment(sizeof(uint32_t)));/* DHEADER */
-            serialize(static_cast<uint32_t>(dheader));
-            set_state(state_after);
-            serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
-        }
+        set_xcdrv2_dheader(dheader_state);
 
         return *this;
     }
@@ -1300,27 +1259,11 @@ public:
     Cdr& serialize_array(
             const std::vector<_T>& value)
     {
-        Cdr::state dheader_state(*this);
-
-        if (CdrVersion::XCDRv2 == cdr_version_)
-        {
-            // Serialize DHEADER
-            uint32_t dheader {0};
-            serialize(dheader);
-        }
+        Cdr::state dheader_state {allocate_xcdrv2_dheader()};
 
         serialize_array(value.data(), value.size());
 
-        if (CdrVersion::XCDRv2 == cdr_version_)
-        {
-            auto offset = offset_;
-            Cdr::state state_after(*this);
-            set_state(dheader_state);
-            size_t dheader = offset - offset_ - (4 + alignment(sizeof(uint32_t)));/* DHEADER */
-            serialize(static_cast<uint32_t>(dheader));
-            set_state(state_after);
-            serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
-        }
+        set_xcdrv2_dheader(dheader_state);
 
         return *this;
     }
@@ -1385,14 +1328,7 @@ public:
             const _T* sequence_t,
             size_t num_elements)
     {
-        Cdr::state dheader_state(*this);
-
-        if (CdrVersion::XCDRv2 == cdr_version_)
-        {
-            // Serialize DHEADER
-            uint32_t dheader {0};
-            serialize(dheader);
-        }
+        Cdr::state dheader_state {allocate_xcdrv2_dheader()};
 
         serialize(static_cast<int32_t>(num_elements));
 
@@ -1406,16 +1342,7 @@ public:
             ex.raise();
         }
 
-        if (CdrVersion::XCDRv2 == cdr_version_)
-        {
-            auto offset = offset_;
-            Cdr::state state_after(*this);
-            set_state(dheader_state);
-            size_t dheader = offset - offset_ - (4 + alignment(sizeof(uint32_t)));/* DHEADER */
-            serialize(static_cast<uint32_t>(dheader));
-            set_state(state_after);
-            serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
-        }
+        set_xcdrv2_dheader(dheader_state);
 
         return *this;
     }
@@ -3012,21 +2939,21 @@ public:
         return *this;
     }
 
-    void set_serialized_member_size()
-    {
-        serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
-    }
+    /*!
+     * @brief Encodes an empty DHEADER if the encoding version is XCDRv2.
+     * After serializing the members's type, @ref set_xcdrv2_dheader must be called to set the correct DHEADER value
+     * using the @ref state returned by this function.
+     */
+    state allocate_xcdrv2_dheader();
 
     /*!
-     * @brief This function returns the extra bytes regarding the allignment.
-     * @param data_size The size of the data that will be serialized.
-     * @return The size needed for the alignment.
+     * @brief Uses the @ref state to calculate the member's type size and serialize the value in the previous allocated
+     * DHEADER.
+     *
+     * @param[in] state @ref state used to calculate the member's type size.
      */
-    inline size_t alignment(
-            size_t data_size) const
-    {
-        return data_size > last_data_size_ ? (data_size - ((offset_ - origin_) % data_size)) & (data_size - 1) : 0;
-    }
+    void set_xcdrv2_dheader(
+            const state& state);
 
 private:
 
@@ -3101,6 +3028,18 @@ private:
             Endianness endianness)
     {
         return deserialize_array(array_t->data(), num_elements * array_t->size(), endianness);
+    }
+
+    /*!
+     * @brief Returns the number of bytes needed to align the current position (having as reference the origin) to
+     * certain data size.
+     * @param data_size The size of the data that will be serialized.
+     * @return The size needed for the alignment.
+     */
+    inline size_t alignment(
+            size_t data_size) const
+    {
+        return data_size > last_data_size_ ? (data_size - ((offset_ - origin_) % data_size)) & (data_size - 1) : 0;
     }
 
     /*!
@@ -3593,13 +3532,16 @@ private:
     //! Align for types equal or greater than 64bits.
     size_t align64_ {4};
 
-
+    /*!
+     * When serializing a member's type using XCDRv2, this enumerator is used to inform the type was serialized with a
+     * DHEADER and the algorithm could optimize the XCDRv2 member header.
+     */
     enum SerializedMemberSizeForNextInt
     {
-        NO_SERIALIZED_MEMBER_SIZE,
-        SERIALIZED_MEMBER_SIZE,
-        SERIALIZED_MEMBER_SIZE_4,
-        SERIALIZED_MEMBER_SIZE_8
+        NO_SERIALIZED_MEMBER_SIZE,     //! Default. No serialized member size in a DHEADER.
+        SERIALIZED_MEMBER_SIZE,        //! Serialized member size in a DHEADER.
+        SERIALIZED_MEMBER_SIZE_4,      //! Serialized member size (which is a multiple of 4) in a DHEADER.
+        SERIALIZED_MEMBER_SIZE_8       //! Serialized member size (which is a multiple of 8) in a DHEADER.
     }
     //! Specifies if a DHEADER was serialized. Used to optimize XCDRv2 member headers.
     serialized_member_size_ {NO_SERIALIZED_MEMBER_SIZE};

--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -3382,5 +3382,34 @@ Cdr& Cdr::cdr_deserialize_type(
     return *this;
 }
 
+Cdr::state Cdr::allocate_xcdrv2_dheader()
+{
+    Cdr::state dheader_state(*this);
+
+    if (CdrVersion::XCDRv2 == cdr_version_)
+    {
+        // Serialize DHEADER
+        uint32_t dheader {0};
+        serialize(dheader);
+    }
+
+    return dheader_state;
+}
+
+void Cdr::set_xcdrv2_dheader(
+        const Cdr::state& dheader_state)
+{
+    if (CdrVersion::XCDRv2 == cdr_version_)
+    {
+        auto offset = offset_;
+        Cdr::state state_after(*this);
+        set_state(dheader_state);
+        size_t dheader = offset - offset_ - (4 + alignment(sizeof(uint32_t)));    /* DHEADER */
+        serialize(static_cast<uint32_t>(dheader));
+        set_state(state_after);
+        serialized_member_size_ = SERIALIZED_MEMBER_SIZE;
+    }
+}
+
 } // namespace fastcdr
 } // namespace eprosima

--- a/src/cpp/CdrSizeCalculator.cpp
+++ b/src/cpp/CdrSizeCalculator.cpp
@@ -32,6 +32,14 @@ CdrSizeCalculator::CdrSizeCalculator(
     }
 }
 
+CdrSizeCalculator::CdrSizeCalculator(
+        CdrVersion cdr_version,
+        EncodingAlgorithmFlag encoding)
+    : cdr_version_(cdr_version)
+    , current_encoding_(encoding)
+{
+}
+
 CdrVersion CdrSizeCalculator::get_cdr_version() const
 {
     return cdr_version_;

--- a/test/cdr/CMakeLists.txt
+++ b/test/cdr/CMakeLists.txt
@@ -21,6 +21,14 @@ target_link_libraries(FixedSizeStringTests fastcdr GTest::gtest_main)
 gtest_discover_tests(FixedSizeStringTests)
 
 ###############################################################################
+# array_as_std_vector tests
+###############################################################################
+add_executable(ArrayAsSTDVectorTests array_as_std_vector.cpp)
+set_common_compile_options(ArrayAsSTDVectorTests)
+target_link_libraries(ArrayAsSTDVectorTests fastcdr GTest::gtest_main)
+gtest_discover_tests(ArrayAsSTDVectorTests)
+
+###############################################################################
 # Old cdr unit tests
 ###############################################################################
 set(UNITTESTS_SOURCE SimpleTest.cpp ResizeTest.cpp)

--- a/test/cdr/array_as_std_vector.cpp
+++ b/test/cdr/array_as_std_vector.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -264,8 +264,6 @@ TEST_P(CdrArrayAsSTDVectorTest, array_ulong_as_std_vector)
     Cdr::Endianness endianness = std::get<1>(GetParam());
 
     serialize_array(expected_streams, encoding, endianness, array_value);
-
-    serialize_array(expected_streams, encoding, endianness, array_value);
 }
 
 /*!
@@ -419,8 +417,6 @@ TEST_P(CdrArrayAsSTDVectorTest, array_struct)
 
     EncodingAlgorithmFlag encoding = std::get<0>(GetParam());
     Cdr::Endianness endianness = std::get<1>(GetParam());
-
-    serialize_array(expected_streams, encoding, endianness, array_value);
 
     serialize_array(expected_streams, encoding, endianness, array_value);
 }

--- a/test/cdr/array_as_std_vector.cpp
+++ b/test/cdr/array_as_std_vector.cpp
@@ -1,0 +1,442 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <fastcdr/Cdr.h>
+#include <fastcdr/CdrSizeCalculator.hpp>
+
+#include "../xcdr/utility.hpp"
+
+using namespace eprosima::fastcdr;
+
+using XCdrStreamValues =
+        std::array<std::vector<uint8_t>,
+                1 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS>;
+
+class CdrArrayAsSTDVectorTest : public ::testing::TestWithParam< std::tuple<EncodingAlgorithmFlag, Cdr::Endianness>>
+{
+};
+
+struct InnerBasicTypesShortStruct
+{
+    InnerBasicTypesShortStruct() = default;
+
+    InnerBasicTypesShortStruct(
+            uint16_t v)
+    {
+        value1 = v;
+        value2 = v;
+    }
+
+    bool operator ==(
+            const InnerBasicTypesShortStruct& other) const
+    {
+        return value1 == other.value1 && value2 == other.value2;
+    }
+
+    uint16_t value1 {0};
+
+    uint16_t value2 {0};
+};
+
+namespace eprosima {
+namespace fastcdr {
+
+template<>
+size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const InnerBasicTypesShortStruct& data,
+        size_t& current_alignment)
+{
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(previous_encoding, current_alignment)};
+
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(
+                        3), data.value1, current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(
+                        0x3FFF), data.value2, current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+void serialize(
+        Cdr& cdr,
+        const InnerBasicTypesShortStruct& data)
+
+{
+    Cdr::state current_status(cdr);
+    cdr.begin_serialize_type(current_status, cdr.get_encoding_flag());
+    cdr << MemberId(3) << data.value1;
+    cdr << MemberId(0x3FFF) << data.value2;
+    cdr.end_serialize_type(current_status);
+}
+
+template<>
+void deserialize(
+        Cdr& cdr,
+        InnerBasicTypesShortStruct& data)
+{
+    cdr.deserialize_type(cdr.get_encoding_flag(), [&data](Cdr& cdr_inner, const MemberId& mid) -> bool
+            {
+                bool ret_value = true;
+                if (EncodingAlgorithmFlag::PL_CDR == cdr_inner.get_encoding_flag() ||
+                EncodingAlgorithmFlag::PL_CDR2 == cdr_inner.get_encoding_flag())
+                {
+                    switch (mid.id)
+                    {
+                        case 3:
+                            cdr_inner >> data.value1;
+                            break;
+                        case 0x3FFF:
+                            cdr_inner >> data.value2;
+                            break;
+                        default:
+                            ret_value = false;
+                            break;
+                    }
+
+                }
+                else
+                {
+                    switch (mid.id)
+                    {
+                        case 0:
+                            cdr_inner >> data.value1;
+                            break;
+                        case 1:
+                            cdr_inner >> data.value2;
+                            break;
+                        default:
+                            ret_value = false;
+                            break;
+                    }
+                }
+
+                return ret_value;
+            });
+}
+
+} // namespace fastcdr
+} // namespace eprosima
+
+template<class _T>
+void serialize_array(
+        const XCdrStreamValues& expected_streams,
+        EncodingAlgorithmFlag encoding,
+        Cdr::Endianness endianness,
+        _T value)
+{
+    //{ Calculate encoded size.
+    CdrSizeCalculator calculator(get_version_from_algorithm(encoding), encoding);
+    size_t current_alignment {0};
+    size_t calculated_size {calculator.calculate_array_serialized_size(value, current_alignment)};
+    calculated_size += 4; // Encapsulation
+    //}
+
+    //{ Prepare buffer
+    uint8_t tested_stream = 0 + encoding + endianness;
+    auto buffer =
+            std::unique_ptr<char, void (*)(
+        void*)>{reinterpret_cast<char*>(calloc(expected_streams[tested_stream].size(), sizeof(char))), free};
+    FastBuffer fast_buffer(buffer.get(), expected_streams[tested_stream].size());
+    Cdr cdr(fast_buffer, endianness, get_version_from_algorithm(encoding));
+    //}
+
+    //{ Encode the value.
+    cdr.set_encoding_flag(encoding);
+    cdr.serialize_encapsulation();
+    Cdr::state enc_state(cdr);
+    cdr.serialize_array(value);
+    Cdr::state enc_state_end(cdr);
+    //}
+
+    //{ Test encoded content
+    ASSERT_EQ(cdr.get_serialized_data_length(), expected_streams[tested_stream].size());
+    ASSERT_EQ(cdr.get_serialized_data_length(), calculated_size);
+    ASSERT_EQ(0, memcmp(buffer.get(), expected_streams[tested_stream].data(), expected_streams[tested_stream].size()));
+    //}
+
+    //{ Decoding the value.
+    _T dvalue(value.size());
+    cdr.reset();
+    cdr.read_encapsulation();
+    ASSERT_EQ(cdr.get_encoding_flag(), encoding);
+    ASSERT_EQ(cdr.endianness(), endianness);
+    cdr.deserialize_array(dvalue);
+    ASSERT_EQ(value, dvalue);
+    Cdr::state dec_state_end(cdr);
+    ASSERT_EQ(enc_state_end, dec_state_end);
+    //}
+}
+
+/*!
+ * @test Test an array of unsigned long type stored in a std::vector.
+ */
+TEST_P(CdrArrayAsSTDVectorTest, array_ulong_as_std_vector)
+{
+    const std::vector<uint32_t> array_value {0xCDCDCDDC, 0xCDCDCDDC};
+    constexpr uint8_t ival {0xCD};
+    constexpr uint8_t fval {0xDC};
+
+    //{ Defining expected XCDR streams
+    XCdrStreamValues expected_streams;
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        ival, ival, ival, fval, // ULong
+        ival, ival, ival, fval  // ULong
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        fval, ival, ival, ival, // ULong
+        fval, ival, ival, ival  // ULong
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x02, 0x00, 0x00, // Encapsulation
+        ival, ival, ival, fval, // ULong
+        ival, ival, ival, fval, // ULong
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x03, 0x00, 0x00, // Encapsulation
+        fval, ival, ival, ival, // ULong
+        fval, ival, ival, ival, // ULong
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        ival, ival, ival, fval, // ULong
+        ival, ival, ival, fval  // ULong
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        fval, ival, ival, ival, // ULong
+        fval, ival, ival, ival  // ULong
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        ival, ival, ival, fval, // ULong
+        ival, ival, ival, fval  // ULong
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        fval, ival, ival, ival, // ULong
+        fval, ival, ival, ival  // ULong
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        ival, ival, ival, fval, // ULong
+        ival, ival, ival, fval  // ULong
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        fval, ival, ival, ival, // ULong
+        fval, ival, ival, ival  // ULong
+    };
+    //}
+
+    EncodingAlgorithmFlag encoding = std::get<0>(GetParam());
+    Cdr::Endianness endianness = std::get<1>(GetParam());
+
+    serialize_array(expected_streams, encoding, endianness, array_value);
+
+    serialize_array(expected_streams, encoding, endianness, array_value);
+}
+
+/*!
+ * @test Test an array of struct type stored in a std::vector.
+ * @code{.idl}
+ * struct InnerBasicTypesShortStruct
+ * {
+ *     @id(3)
+ *     unsigned short value1;
+ *     @id(16383)
+ *     unsigned short value2;
+ * };
+ *
+ * InnerBasicTypesShortStruct var_structarray[2];
+ *
+ * @endcode
+ */
+TEST_P(CdrArrayAsSTDVectorTest, array_struct)
+{
+    const std::vector<InnerBasicTypesShortStruct> array_value {{{0xCDDC}, {0xDCCD}}};
+    constexpr uint8_t ival {0xCD};
+    constexpr uint8_t fval {0xDC};
+
+    //{ Defining expected XCDR streams
+    XCdrStreamValues expected_streams;
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        ival, fval, ival, fval, // Array element 0
+        fval, ival, fval, ival  // Array element 1
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        fval, ival, fval, ival, // Array element 0
+        ival, fval, ival, fval  // Array element 1
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x02, 0x00, 0x00, // Encapsulation
+        0x00, 0x03, 0x00, 0x02, // ShortMemberHeader
+        ival, fval,
+        0x00, 0x00,             // Alignment
+        0x3F, 0x01, 0x00, 0x08, // LongMemberHeader
+        0x00, 0x00, 0x3F, 0xFF, // LongMemberHeader
+        0x00, 0x00, 0x00, 0x02, // LongMemberHeader
+        ival, fval,
+        0x00, 0x00,             // Alignment
+        0x3F, 0x02, 0x00, 0x00, // Sentinel
+        0x00, 0x03, 0x00, 0x02, // ShortMemberHeader
+        fval, ival,
+        0x00, 0x00,             // Alignment
+        0x3F, 0x01, 0x00, 0x08, // LongMemberHeader
+        0x00, 0x00, 0x3F, 0xFF, // LongMemberHeader
+        0x00, 0x00, 0x00, 0x02, // LongMemberHeader
+        fval, ival,
+        0x00, 0x00,             // Alignment
+        0x3F, 0x02, 0x00, 0x00, // Sentinel
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x03, 0x00, 0x00, // Encapsulation
+        0x03, 0x00, 0x02, 0x00, // ShortMemberHeader
+        fval, ival,
+        0x00, 0x00,             // Alignment
+        0x01, 0x3F, 0x08, 0x00, // LongMemberHeader
+        0xFF, 0x3F, 0x00, 0x00, // LongMemberHeader
+        0x02, 0x00, 0x00, 0x00, // LongMemberHeader
+        fval, ival,
+        0x00, 0x00,             // Alignment
+        0x02, 0x3F, 0x00, 0x00, // Sentinel
+        0x03, 0x00, 0x02, 0x00, // ShortMemberHeader
+        ival, fval,
+        0x00, 0x00,             // Alignment
+        0x01, 0x3F, 0x08, 0x00, // LongMemberHeader
+        0xFF, 0x3F, 0x00, 0x00, // LongMemberHeader
+        0x02, 0x00, 0x00, 0x00, // LongMemberHeader
+        ival, fval,
+        0x00, 0x00,             // Alignment
+        0x02, 0x3F, 0x00, 0x00, // Sentinel
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x08, // DHEADER
+        ival, fval, ival, fval, // Array element 0
+        fval, ival, fval, ival  // Array element 1
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x08, 0x00, 0x00, 0x00, // DHEADER
+        fval, ival, fval, ival, // Array element 0
+        ival, fval, ival, fval  // Array element 1
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x10, // DHEADER
+        0x00, 0x00, 0x00, 0x04, // DHEADER
+        ival, fval, ival, fval, // Array element 0
+        0x00, 0x00, 0x00, 0x04, // DHEADER
+        fval, ival, fval, ival  // Array element 1
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x10, 0x00, 0x00, 0x00, // DHEADER
+        0x04, 0x00, 0x00, 0x00, // DHEADER
+        fval, ival, fval, ival, // Array element 0
+        0x04, 0x00, 0x00, 0x00, // DHEADER
+        ival, fval, ival, fval  // Array element 1
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x26, // DHEADER
+        0x00, 0x00, 0x00, 0x0E, // DHEADER
+        0x10, 0x00, 0x00, 0x03, // EMHEADER1(M) without NEXTINT
+        ival, fval,
+        0x00, 0x00,             // Alignment
+        0x10, 0x00, 0x3F, 0xFF, // EMHEADER1(M) without NEXTINT
+        ival, fval,
+        0x00, 0x00,             // Alignment
+        0x00, 0x00, 0x00, 0x0E, // DHEADER
+        0x10, 0x00, 0x00, 0x03, // EMHEADER1(M) without NEXTINT
+        fval, ival,
+        0x00, 0x00,             // Alignment
+        0x10, 0x00, 0x3F, 0xFF, // EMHEADER1(M) without NEXTINT
+        fval, ival
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x26, 0x00, 0x00, 0x00, // DHEADER
+        0x0E, 0x00, 0x00, 0x00, // DHEADER
+        0x03, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
+        fval, ival,
+        0x00, 0x00,             // Alignment
+        0xFF, 0x3F, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
+        fval, ival,
+        0x00, 0x00,             // Alignment
+        0x0E, 0x00, 0x00, 0x00, // DHEADER
+        0x03, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
+        ival, fval,
+        0x00, 0x00,             // Alignment
+        0xFF, 0x3F, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
+        ival, fval
+    };
+    //}
+
+    EncodingAlgorithmFlag encoding = std::get<0>(GetParam());
+    Cdr::Endianness endianness = std::get<1>(GetParam());
+
+    serialize_array(expected_streams, encoding, endianness, array_value);
+
+    serialize_array(expected_streams, encoding, endianness, array_value);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CdrTest,
+    CdrArrayAsSTDVectorTest,
+    ::testing::Values(
+        std::make_tuple(EncodingAlgorithmFlag::PLAIN_CDR, Cdr::Endianness::BIG_ENDIANNESS),
+        std::make_tuple(EncodingAlgorithmFlag::PLAIN_CDR, Cdr::Endianness::LITTLE_ENDIANNESS),
+        std::make_tuple(EncodingAlgorithmFlag::PL_CDR, Cdr::Endianness::BIG_ENDIANNESS),
+        std::make_tuple(EncodingAlgorithmFlag::PL_CDR, Cdr::Endianness::LITTLE_ENDIANNESS),
+        std::make_tuple(EncodingAlgorithmFlag::PLAIN_CDR2, Cdr::Endianness::BIG_ENDIANNESS),
+        std::make_tuple(EncodingAlgorithmFlag::PLAIN_CDR2, Cdr::Endianness::LITTLE_ENDIANNESS),
+        std::make_tuple(EncodingAlgorithmFlag::DELIMIT_CDR2, Cdr::Endianness::BIG_ENDIANNESS),
+        std::make_tuple(EncodingAlgorithmFlag::DELIMIT_CDR2, Cdr::Endianness::LITTLE_ENDIANNESS),
+        std::make_tuple(EncodingAlgorithmFlag::PL_CDR2, Cdr::Endianness::BIG_ENDIANNESS),
+        std::make_tuple(EncodingAlgorithmFlag::PL_CDR2, Cdr::Endianness::LITTLE_ENDIANNESS)
+        ));


### PR DESCRIPTION
This PR adds API for encoding/decoding a `std::vector` as an array. This API is needed for Fast DDS 3.0 Dynamic Types.