### PR TITLE
[20411] Migrate to eProsima-CI

### DIFF
--- a/.github/workflows/fastcdr-test.yml
+++ b/.github/workflows/fastcdr-test.yml
@@ -57,17 +57,17 @@ jobs:
 
     steps:
     - name: Sync eProsima/Fast-CDR repository
-      uses: eProsima/eProsima-CI/external/checkout@feature/ctest2junit_translation
+      uses: eProsima/eProsima-CI/external/checkout@v0
       with:
           path: src/Fast-CDR
 
     - name: Get minimum supported version of CMake
-      uses: eProsima/eProsima-CI/external/get-cmake@feature/ctest2junit_translation
+      uses: eProsima/eProsima-CI/external/get-cmake@v0
       with:
         cmakeVersion: '3.22.6'
 
     - name: Install Colcon dependencies
-      uses: eProsima/eProsima-CI/multiplatform/install_colcon@feature/ctest2junit_translation
+      uses: eProsima/eProsima-CI/multiplatform/install_colcon@v0
 
     # Temporal step as this platform will be discontinued soon
     - name: Install Gtest Backwards Compatibility
@@ -80,10 +80,10 @@ jobs:
 
     - name: Install Gtest
       if: ${{ matrix.runner-image != 'ubuntu-20.04' }}
-      uses: eProsima/eProsima-CI/multiplatform/install_gtest@feature/ctest2junit_translation
+      uses: eProsima/eProsima-CI/multiplatform/install_gtest@v0
 
     - name: Colcon build
-      uses: eProsima/eProsima-CI/multiplatform/colcon_build@feature/ctest2junit_translation
+      uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
       with:
         colcon_build_args_default: --event-handlers=console_direct+
         cmake_args: ${{ inputs.cmake_args }}
@@ -93,7 +93,7 @@ jobs:
 
     - name: Colcon test
       id: test
-      uses: eProsima/eProsima-CI/multiplatform/colcon_test@feature/ctest2junit_translation
+      uses: eProsima/eProsima-CI/multiplatform/colcon_test@v0
       with:
         colcon_test_args_default: --event-handlers=console_direct+ --return-code-on-test-failure
         ctest_args: ${{ inputs.ctest_args }}
@@ -102,7 +102,7 @@ jobs:
         workspace: ${{ github.workspace }}
 
     - name: Test summary
-      uses: eProsima/eProsima-CI/multiplatform/junit_summary@feature/ctest2junit_translation
+      uses: eProsima/eProsima-CI/multiplatform/junit_summary@v0
       if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}
       with:
         junit_reports_dir: "${{ steps.test.outputs.ctest_results_path }}"
@@ -112,7 +112,7 @@ jobs:
         show_skipped: 'False'
 
     - name: Test Report
-      uses: eProsima/eProsima-CI/external/test-reporter@feature/ctest2junit_translation
+      uses: eProsima/eProsima-CI/external/test-reporter@v0
       if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}
       with:
         name: "Report: ${{ matrix.runner-image }}"

--- a/.github/workflows/fastcdr-test.yml
+++ b/.github/workflows/fastcdr-test.yml
@@ -101,6 +101,16 @@ jobs:
         packages_names: fastcdr
         workspace: ${{ github.workspace }}
 
+    - name: Test summary
+      uses: eProsima/eProsima-CI/multiplatform/junit_summary@feature/ctest2junit_translation
+      if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}
+      with:
+        junit_reports_dir: "${{ steps.test.outputs.ctest_results_path }}"
+        print_summary: 'True'
+        show_failed: 'True'
+        show_disabled: 'False'
+        show_skipped: 'False'
+
     - name: Test Report
       uses: eProsima/eProsima-CI/external/test-reporter@feature/ctest2junit_translation
       if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}

--- a/.github/workflows/fastcdr-test.yml
+++ b/.github/workflows/fastcdr-test.yml
@@ -40,36 +40,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
-#############################
-######  UBUNTU BUILD  #######
-#############################
-  ubuntu-build-and-test:
+  build-and-test:
     name: Colcon build and test
 
     if: ${{ !(contains(github.event.pull_request.labels.*.name, 'no-test') ||
               contains(github.event.pull_request.labels.*.name, 'skip-ci')) }}
 
-    runs-on: ${{ matrix.ubuntu-version }}
+    runs-on: ${{ matrix.runner-image }}
     strategy:
       fail-fast: false
       matrix:
-        ubuntu-version:
+        runner-image:
           - 'ubuntu-20.04'
           - 'ubuntu-22.04'
+          - 'windows-2019'
 
     steps:
     - name: Sync eProsima/Fast-CDR repository
-      uses: actions/checkout@v3
+      uses: eProsima/eProsima-CI/external/checkout@feature/ctest2junit_translation
       with:
           path: src/Fast-CDR
 
+    - name: Get minimum supported version of CMake
+      uses: eProsima/eProsima-CI/external/get-cmake@feature/ctest2junit_translation
+      with:
+        cmakeVersion: '3.20.6'
+
     - name: Install Colcon dependencies
-      uses: eProsima/eProsima-CI/ubuntu/install_colcon@main
+      uses: eProsima/eProsima-CI/multiplatform/install_colcon@feature/ctest2junit_translation
 
     # Temporal step as this platform will be discontinued soon
     - name: Install Gtest Backwards Compatibility
-      if: ${{ matrix.ubuntu-version == 'ubuntu-20.04' }}
+      if: ${{ matrix.runner-image == 'ubuntu-20.04' }}
       run: |
           git clone --branch release-1.12.1 https://github.com/google/googletest.git && \
           colcon build \
@@ -77,28 +79,41 @@ jobs:
             --packages-select googletest-distribution
 
     - name: Install Gtest
-      if: ${{ matrix.ubuntu-version == 'ubuntu-22.04' }}
-      uses: eProsima/eProsima-CI/ubuntu/install_gtest@feature/install_gtest
+      if: ${{ matrix.runner-image != 'ubuntu-20.04' }}
+      uses: eProsima/eProsima-CI/multiplatform/install_gtest@feature/ctest2junit_translation
 
-    - name: Build
-      run: |
-        colcon build \
-            --event-handlers=console_direct+ \
-            --packages-select fastcdr \
-            --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=ON \
-            ${{ inputs.cmake_args }}
+    - name: Colcon build
+      uses: eProsima/eProsima-CI/multiplatform/colcon_build@feature/ctest2junit_translation
+      with:
+        colcon_build_args_default: --event-handlers=console_direct+
+        cmake_args: ${{ inputs.cmake_args }}
+        cmake_args_default: -DBUILD_TESTING=ON
+        cmake_build_type: RelWithDebInfo
+        workspace: ${{ github.workspace }}
 
-    - name: Run Tests
-      run: |
-        colcon test \
-            --event-handlers=console_direct+ \
-            --packages-select fastcdr \
-            --return-code-on-test-failure \
-            --ctest-args ${{ inputs.ctest_args }}
+    - name: Colcon test
+      id: test
+      uses: eProsima/eProsima-CI/multiplatform/colcon_test@feature/ctest2junit_translation
+      with:
+        colcon_test_args_default: --event-handlers=console_direct+ --return-code-on-test-failure
+        ctest_args: ${{ inputs.ctest_args }}
+        ctest_args_default: --repeat until-pass:3 --timeout 300 --output-junit junit/junit.xml
+        packages_names: fastcdr
+        workspace: ${{ github.workspace }}
+
+    - name: Test Report
+      uses: eProsima/eProsima-CI/external/test-reporter@feature/ctest2junit_translation
+      if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}
+      with:
+        name: "Report: ${{ matrix.runner-image }}"
+        path: "${{ steps.test.outputs.ctest_results_path }}*.xml"
+        working-directory: 'src/Fast-CDR'
+        path-replace-backslashes: 'true'
+        list-tests: 'failed'
 
     - name: Archive Test Results
       if: always()
       uses: actions/upload-artifact@v1
       with:
-        name: test-results-${{ matrix.ubuntu-version }}
+        name: test-results-${{ matrix.runner-image }}
         path: log/latest_test/fastcdr

--- a/.github/workflows/fastcdr-test.yml
+++ b/.github/workflows/fastcdr-test.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Get minimum supported version of CMake
       uses: eProsima/eProsima-CI/external/get-cmake@feature/ctest2junit_translation
       with:
-        cmakeVersion: '3.20.6'
+        cmakeVersion: '3.22.6'
 
     - name: Install Colcon dependencies
       uses: eProsima/eProsima-CI/multiplatform/install_colcon@feature/ctest2junit_translation

--- a/cmake/testing/GoogleTest.cmake
+++ b/cmake/testing/GoogleTest.cmake
@@ -15,6 +15,7 @@
 include(GoogleTest)
 
 function(gtest_discover_tests TARGET)
+    cmake_minimum_required(VERSION 3.22)
     if (WIN32)
         add_custom_command(
             TARGET ${TARGET} POST_BUILD


### PR DESCRIPTION
This PR:

* Refactors the build_and_test workflow so it becomes full multiplatform leveraging eProsima-CI
* Fixes the CMake version used in CI
* Adds a `windows-2019` runner to the list of tests
* Adds a Test summary step to the build_and_test workflow
* Adds a Test reporting step to the build_and_test workflow
* Correctly requires CMake 3.22 for testing

Depends on:
* eProsima/eProsima-CI#56