### PR TITLE
[20091] Add macOS to gihub actions testing

### DIFF
--- a/.github/workflows/config/colcon.meta
+++ b/.github/workflows/config/colcon.meta
@@ -1,0 +1,6 @@
+names:
+    googletest-distribution:
+        cmake-args:
+            - "-Dgtest_force_shared_crt=ON"
+            - "-DBUILD_SHARED_LIBS=ON"
+            - "-DBUILD_GMOCK=ON"

--- a/.github/workflows/fastcdr-test.yml
+++ b/.github/workflows/fastcdr-test.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - master
+      - 1.1.x
       - 1.0.x
 
   workflow_dispatch:
@@ -30,6 +31,7 @@ on:
   pull_request:
     branches:
       - master
+      - 1.1.x
       - 1.0.x
     paths-ignore:
       - '**.md'
@@ -60,7 +62,14 @@ jobs:
     - name: Sync eProsima/Fast-CDR repository
       uses: eProsima/eProsima-CI/external/checkout@feature/fastdds_mac_ci_support
       with:
-          path: src/Fast-CDR
+        path: src/Fast-CDR
+
+    - name: Sync GTest
+      uses: eProsima/eProsima-CI/external/checkout@feature/fastdds_mac_ci_support
+      with:
+        path: src/googletest
+        repository: google/googletest
+        ref: 'release-1.12.1'
 
     - uses: eProsima/eProsima-CI/external/setup-python@feature/fastdds_mac_ci_support
       with:
@@ -73,19 +82,6 @@ jobs:
 
     - name: Install Colcon dependencies
       uses: eProsima/eProsima-CI/multiplatform/install_colcon@feature/fastdds_mac_ci_support
-
-    # Temporal step as this platform will be discontinued soon
-    - name: Install Gtest Backwards Compatibility
-      if: ${{ matrix.runner-image == 'ubuntu-20.04' || matrix.runner-image == 'macos-13' }}
-      run: |
-          git clone --branch release-1.12.1 https://github.com/google/googletest.git src/googletest && \
-          colcon build \
-            --event-handlers=console_direct+ \
-            --packages-select googletest-distribution
-
-    - name: Install Gtest
-      if: ${{ matrix.runner-image != 'ubuntu-20.04' && matrix.runner-image != 'macos-13' }}
-      uses: eProsima/eProsima-CI/multiplatform/install_gtest@feature/fastdds_mac_ci_support
 
     - name: Colcon build
       uses: eProsima/eProsima-CI/multiplatform/colcon_build@feature/fastdds_mac_ci_support
@@ -110,7 +106,7 @@ jobs:
       uses: eProsima/eProsima-CI/multiplatform/junit_summary@feature/fastdds_mac_ci_support
       if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}
       with:
-        junit_reports_dir: "${{ steps.test.outputs.ctest_results_path }}"
+        junit_reports_dir: ${{ steps.test.outputs.ctest_results_path }}
         print_summary: 'True'
         show_failed: 'True'
         show_disabled: 'False'

--- a/.github/workflows/fastcdr-test.yml
+++ b/.github/workflows/fastcdr-test.yml
@@ -60,31 +60,31 @@ jobs:
 
     steps:
     - name: Sync eProsima/Fast-CDR repository
-      uses: eProsima/eProsima-CI/external/checkout@feature/fastdds_mac_ci_support
+      uses: eProsima/eProsima-CI/external/checkout@v0
       with:
         path: src/Fast-CDR
 
     - name: Sync GTest
-      uses: eProsima/eProsima-CI/external/checkout@feature/fastdds_mac_ci_support
+      uses: eProsima/eProsima-CI/external/checkout@v0
       with:
         path: src/googletest
         repository: google/googletest
         ref: 'release-1.12.1'
 
-    - uses: eProsima/eProsima-CI/external/setup-python@feature/fastdds_mac_ci_support
+    - uses: eProsima/eProsima-CI/external/setup-python@v0
       with:
         python-version: '3.11'
 
     - name: Get minimum supported version of CMake
-      uses: eProsima/eProsima-CI/external/get-cmake@feature/fastdds_mac_ci_support
+      uses: eProsima/eProsima-CI/external/get-cmake@v0
       with:
         cmakeVersion: '3.22.6'
 
     - name: Install Colcon dependencies
-      uses: eProsima/eProsima-CI/multiplatform/install_colcon@feature/fastdds_mac_ci_support
+      uses: eProsima/eProsima-CI/multiplatform/install_colcon@v0
 
     - name: Colcon build
-      uses: eProsima/eProsima-CI/multiplatform/colcon_build@feature/fastdds_mac_ci_support
+      uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
       with:
         colcon_meta_file: ${{ github.workspace }}/src/Fast-CDR/.github/workflows/config/colcon.meta
         colcon_build_args_default: --event-handlers=console_direct+
@@ -95,7 +95,7 @@ jobs:
 
     - name: Colcon test
       id: test
-      uses: eProsima/eProsima-CI/multiplatform/colcon_test@feature/fastdds_mac_ci_support
+      uses: eProsima/eProsima-CI/multiplatform/colcon_test@v0
       with:
         colcon_test_args_default: --event-handlers=console_direct+ --return-code-on-test-failure
         ctest_args: ${{ inputs.ctest_args }}
@@ -104,7 +104,7 @@ jobs:
         workspace: ${{ github.workspace }}
 
     - name: Test summary
-      uses: eProsima/eProsima-CI/multiplatform/junit_summary@feature/fastdds_mac_ci_support
+      uses: eProsima/eProsima-CI/multiplatform/junit_summary@v0
       if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}
       with:
         junit_reports_dir: ${{ steps.test.outputs.ctest_results_path }}
@@ -114,7 +114,7 @@ jobs:
         show_skipped: 'False'
 
     - name: Test Report
-      uses: eProsima/eProsima-CI/external/test-reporter@feature/fastdds_mac_ci_support
+      uses: eProsima/eProsima-CI/external/test-reporter@v0
       if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}
       with:
         name: "Report: ${{ matrix.runner-image }}"
@@ -125,7 +125,7 @@ jobs:
 
     - name: Archive Test Results
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: eProsima/eProsima-CI/external/upload-artifact@v0
       with:
         name: test-results-${{ matrix.runner-image }}
         path: log/latest_test/fastcdr

--- a/.github/workflows/fastcdr-test.yml
+++ b/.github/workflows/fastcdr-test.yml
@@ -54,20 +54,21 @@ jobs:
           - 'ubuntu-20.04'
           - 'ubuntu-22.04'
           - 'windows-2019'
+          - 'macos-13'
 
     steps:
     - name: Sync eProsima/Fast-CDR repository
-      uses: eProsima/eProsima-CI/external/checkout@v0
+      uses: eProsima/eProsima-CI/external/checkout@feature/fastdds_mac_ci_support
       with:
           path: src/Fast-CDR
 
     - name: Get minimum supported version of CMake
-      uses: eProsima/eProsima-CI/external/get-cmake@v0
+      uses: eProsima/eProsima-CI/external/get-cmake@feature/fastdds_mac_ci_support
       with:
         cmakeVersion: '3.22.6'
 
     - name: Install Colcon dependencies
-      uses: eProsima/eProsima-CI/multiplatform/install_colcon@v0
+      uses: eProsima/eProsima-CI/multiplatform/install_colcon@feature/fastdds_mac_ci_support
 
     # Temporal step as this platform will be discontinued soon
     - name: Install Gtest Backwards Compatibility
@@ -80,10 +81,10 @@ jobs:
 
     - name: Install Gtest
       if: ${{ matrix.runner-image != 'ubuntu-20.04' }}
-      uses: eProsima/eProsima-CI/multiplatform/install_gtest@v0
+      uses: eProsima/eProsima-CI/multiplatform/install_gtest@feature/fastdds_mac_ci_support
 
     - name: Colcon build
-      uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
+      uses: eProsima/eProsima-CI/multiplatform/colcon_build@feature/fastdds_mac_ci_support
       with:
         colcon_build_args_default: --event-handlers=console_direct+
         cmake_args: ${{ inputs.cmake_args }}
@@ -93,7 +94,7 @@ jobs:
 
     - name: Colcon test
       id: test
-      uses: eProsima/eProsima-CI/multiplatform/colcon_test@v0
+      uses: eProsima/eProsima-CI/multiplatform/colcon_test@feature/fastdds_mac_ci_support
       with:
         colcon_test_args_default: --event-handlers=console_direct+ --return-code-on-test-failure
         ctest_args: ${{ inputs.ctest_args }}
@@ -102,7 +103,7 @@ jobs:
         workspace: ${{ github.workspace }}
 
     - name: Test summary
-      uses: eProsima/eProsima-CI/multiplatform/junit_summary@v0
+      uses: eProsima/eProsima-CI/multiplatform/junit_summary@feature/fastdds_mac_ci_support
       if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}
       with:
         junit_reports_dir: "${{ steps.test.outputs.ctest_results_path }}"
@@ -112,7 +113,7 @@ jobs:
         show_skipped: 'False'
 
     - name: Test Report
-      uses: eProsima/eProsima-CI/external/test-reporter@v0
+      uses: eProsima/eProsima-CI/external/test-reporter@feature/fastdds_mac_ci_support
       if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}
       with:
         name: "Report: ${{ matrix.runner-image }}"

--- a/.github/workflows/fastcdr-test.yml
+++ b/.github/workflows/fastcdr-test.yml
@@ -86,6 +86,7 @@ jobs:
     - name: Colcon build
       uses: eProsima/eProsima-CI/multiplatform/colcon_build@feature/fastdds_mac_ci_support
       with:
+        colcon_meta_file: ${{ github.workspace }}/src/Fast-CDR/.github/workflows/config/colcon.meta
         colcon_build_args_default: --event-handlers=console_direct+
         cmake_args: ${{ inputs.cmake_args }}
         cmake_args_default: -DBUILD_TESTING=ON

--- a/.github/workflows/fastcdr-test.yml
+++ b/.github/workflows/fastcdr-test.yml
@@ -76,15 +76,15 @@ jobs:
 
     # Temporal step as this platform will be discontinued soon
     - name: Install Gtest Backwards Compatibility
-      if: ${{ matrix.runner-image == 'ubuntu-20.04' }}
+      if: ${{ matrix.runner-image == 'ubuntu-20.04' || matrix.runner-image == 'macos-13' }}
       run: |
-          git clone --branch release-1.12.1 https://github.com/google/googletest.git && \
+          git clone --branch release-1.12.1 https://github.com/google/googletest.git src/googletest && \
           colcon build \
             --event-handlers=console_direct+ \
             --packages-select googletest-distribution
 
     - name: Install Gtest
-      if: ${{ matrix.runner-image != 'ubuntu-20.04' }}
+      if: ${{ matrix.runner-image != 'ubuntu-20.04' && matrix.runner-image != 'macos-13' }}
       uses: eProsima/eProsima-CI/multiplatform/install_gtest@feature/fastdds_mac_ci_support
 
     - name: Colcon build

--- a/.github/workflows/fastcdr-test.yml
+++ b/.github/workflows/fastcdr-test.yml
@@ -62,6 +62,10 @@ jobs:
       with:
           path: src/Fast-CDR
 
+    - uses: eProsima/eProsima-CI/external/setup-python@feature/fastdds_mac_ci_support
+      with:
+        python-version: '3.11'
+
     - name: Get minimum supported version of CMake
       uses: eProsima/eProsima-CI/external/get-cmake@feature/fastdds_mac_ci_support
       with:


### PR DESCRIPTION
This PR adds macOS 13 to the list of platforms tested in Github CI. Depends on:

* eProsima/eProsima-CI#44

@mergifyio backport 1.1.x 1.0.x