### PR TITLE
[20328] Add support for building tests within an ament context

### DIFF
--- a/cmake/common/find_or_add_gtest.cmake
+++ b/cmake/common/find_or_add_gtest.cmake
@@ -1,0 +1,40 @@
+# Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+macro(find_or_add_gtest)
+    # Check if building on an ament context, i.e. ROS 2
+    # Thanks to https://github.com/facontidavide/PlotJuggler/blob/main/CMakeLists.txt#L66
+    find_package(ament_cmake QUIET)
+
+    # This is a ROS 2 build
+    if(ament_cmake_FOUND)
+        # Find all GTest vendor required packages
+        find_package(ament_cmake REQUIRED)
+        find_package(gtest_vendor REQUIRED)
+        find_package(ament_cmake_gtest REQUIRED)
+
+        # Find GTest
+        ament_find_gtest()
+
+        # Add aliases for GTest libraries so we can use them as targets independently of the context
+        add_library(GTest::gtest ALIAS gtest)
+        add_library(GTest::gtest_main ALIAS gtest_main)
+        target_link_libraries(gtest_main gtest)
+
+    # This is a non-ROS 2 build
+    else()
+        # Find GTest normally
+        find_package(GTest CONFIG REQUIRED)
+    endif()
+endmacro()

--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,5 +1,8 @@
-{
-    "name": "fastcdr",
-    "type": "cmake",
-    "dependencies" : ["googletest-distribution"]
-}
+name: fastcdr
+type: cmake
+dependencies:
+    # Needed for test compilation in ROS 2 CI
+    - ament_cmake_gtest
+    - ament_cmake
+    # Needed for test compilation in eProsima CI
+    - googletest-distribution

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>fastcdr</name>
+  <version>2.1.3</version>
+  <description>
+    *eProsima Fast CDR* is a C++ serialization library implementing the Common Data Representation (CDR) mechanism defined by the Object Management Group (OMG) consortium. CDR is the serialization mechanism used in DDS for the DDS Interoperability Wire Protocol (DDSI-RTPS).
+  </description>
+  <maintainer email="miguelcompany@eprosima.com">Miguel Company</maintainer>
+  <maintainer email="eduardoponz@eprosima.com">Eduardo Ponz</maintainer>
+  <license file="LICENSE">Apache 2.0</license>
+
+  <url type="website">https://www.eprosima.com/</url>
+  <url type="bugtracker">https://github.com/eProsima/Fast-CDR/issues</url>
+  <url type="repository">https://github.com/eProsima/Fast-CDR</url>
+
+  <buildtool_depend>cmake</buildtool_depend>
+  <doc_depend>doxygen</doc_depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake</test_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,7 +20,7 @@ check_stdcxx(${FORCE_CXX})
 include(${PROJECT_SOURCE_DIR}/cmake/common/find_or_add_gtest.cmake)
 find_or_add_gtest()
 
-# Inclue functions to find and add tests dinamically
+# Include functions to find and add tests dinamically
 include(${PROJECT_SOURCE_DIR}/cmake/testing/GoogleTest.cmake)
 
 add_subdirectory(cdr)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(GTest CONFIG REQUIRED)
+# Require C++ 14 for testing (since ROS 2 requires it anyways)
+include(${PROJECT_SOURCE_DIR}/cmake/common/check_configuration.cmake)
+set(FORCE_CXX "14")
+check_stdcxx(${FORCE_CXX})
+
+# Find GTest
+include(${PROJECT_SOURCE_DIR}/cmake/common/find_or_add_gtest.cmake)
+find_or_add_gtest()
+
+# Inclue functions to find and add tests dinamically
 include(${PROJECT_SOURCE_DIR}/cmake/testing/GoogleTest.cmake)
 
 add_subdirectory(cdr)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 # Require C++ 14 for testing (since ROS 2 requires it anyways)
-include(${PROJECT_SOURCE_DIR}/cmake/common/check_configuration.cmake)
 set(FORCE_CXX "14")
 check_stdcxx(${FORCE_CXX})
 


### PR DESCRIPTION
This PR adds support for building Fast CDR within an ament context (as is the ROS 2 CI).

Since Fast CDR v2.0.0, the CMake option to build the tests is the CMake standard `-DBUILD_TESTING=ON`. When trying to introduce Fast CDR v2 in ROS 2, ROS 2 CI was failing because that CI builds all packages with `-DBUILD_TESTING=ON`, and in that context Fast CDR could not find GTest because is not installed in the system.

In the ROS 2 ecosystem, there are vendor packages within ament for GTest, which are the ones the CI is using. However, Fast CDR's CMakeLists.txt was doing a plain `find_package(GTest REQUIRED)`, and thus failing. In order to find GTest in that context, ament's infrastructure needs to be used. This PR:

1. Adds a package.xml to Fast CDR for ROS 2 packaging. This means that when Fast CDR v2.2.0 in included in ROS 2 Rolling, we could dispose of [this patch file](https://github.com/ros2-gbp/fastcdr-release/blob/master/rolling/package.xml).
2. Extends the existing colcon.pkg to included the ament dependencies so the build order is correctly set by colcon. We cannot simply dispose of this file, as then colcon does not build GTest before Fast CDR when building tests.
3. Adds a CMake macro `find_or_add_gtest` to correctly include GTest both in and outside an ament context.
4. Forces C++14 when building tests, as in at the moment ROS 2 Rolling uses GTest 1.14, which requires it, and our CI system supports it. For building the library, C++11 is still the minimum required and is still enforced by default.

Thanks to @clalancette and @mjcarroll for their help on this