### PR TITLE
[20494] Bump version to 2.2.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,11 +15,17 @@ on:
   push:
     branches:
       - master
+      - 2.2.x
+      - 2.1.x
+      - 1.1.x
       - 1.0.x
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
       - master
+      - 2.2.x
+      - 2.1.x
+      - 1.1.x
       - 1.0.x
   schedule:
     - cron: '45 16 * * 0'
@@ -40,7 +46,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/fastcdr-test.yml
+++ b/.github/workflows/fastcdr-test.yml
@@ -12,6 +12,8 @@ on:
   push:
     branches:
       - master
+      - 2.2.x
+      - 2.1.x
       - 1.1.x
       - 1.0.x
 
@@ -31,6 +33,8 @@ on:
   pull_request:
     branches:
       - master
+      - 2.2.x
+      - 2.1.x
       - 1.1.x
       - 1.0.x
     paths-ignore:

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         dest_branch:
-          - '2.1.x'
+          - '2.2.x'
     steps:
     - name: Mirror action step
       id: mirror

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 ###############################################################################
 # Project                                                                     #
 ###############################################################################
-project(fastcdr VERSION 2.1.3 LANGUAGES CXX)
+project(fastcdr VERSION 2.2.0 LANGUAGES CXX)
 
 set(PROJECT_NAME_STYLED "FastCDR")
 set(PROJECT_NAME_LARGE "Fast CDR")

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>fastcdr</name>
-  <version>2.1.3</version>
+  <version>2.2.0</version>
   <description>
     *eProsima Fast CDR* is a C++ serialization library implementing the Common Data Representation (CDR) mechanism defined by the Object Management Group (OMG) consortium. CDR is the serialization mechanism used in DDS for the DDS Interoperability Wire Protocol (DDSI-RTPS).
   </description>


### PR DESCRIPTION
This PR bumps Fast CDR version to 2.2.0 and updates the corresponding workflows