### PR TITLE
[20494] Set 2.1.x as version in fastcdr.repos

### DIFF
--- a/fastcdr.repos
+++ b/fastcdr.repos
@@ -2,4 +2,4 @@ repositories:
     fastcdr:
         type: git
         url: https://github.com/eProsima/Fast-CDR.git
-        version: master
+        version: 2.1.x


### PR DESCRIPTION
This PR sets 2.1.x as version in fastcdr.repos