### PR TITLE
Change version in package.xml format

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<package format="3">
   <name>fastcdr</name>
   <version>2.2.1</version>
   <description>


### PR DESCRIPTION
After https://github.com/ros2/ros2/pull/1530 has been merged, following ROS 2 [Ubuntu (source)](https://docs.ros.org/en/rolling/Installation/Alternatives/Ubuntu-Development-Setup.html#ubuntu-source) installation instructions fails in step `rosdep install` with the following error:

```
Error(s) in package '/root/ros2_ws/src/eProsima/Fast-CDR/package.xml':
Error(s):
- The "license" tag must not have the following attributes: file
```

This PR fixes that issue by changing the `format` of the `package` tag to version 3.