### PR TITLE
Fix a compile warning with g++ 13.2.0.

### DIFF
--- a/test/cdr/ResizeTest.cpp
+++ b/test/cdr/ResizeTest.cpp
@@ -22,8 +22,6 @@
 
 #include <gtest/gtest.h>
 
-#define EXPECT_LONG_DOUBLE_EQ(val1, val2) (val1 == val2)
-
 using namespace eprosima::fastcdr;
 using namespace ::exception;
 
@@ -178,6 +176,14 @@ static void EXPECT_ARRAY_DOUBLE_EQ(
     {
         EXPECT_DOUBLE_EQ(array1[count], array2[count]);
     }
+}
+
+static void EXPECT_LONG_DOUBLE_EQ(
+        const long double val1,
+        const long double val2)
+{
+	static_cast<void>(val1);
+	static_cast<void>(val2);
 }
 
 static void EXPECT_ARRAY_LONG_DOUBLE_EQ(

--- a/test/cdr/ResizeTest.cpp
+++ b/test/cdr/ResizeTest.cpp
@@ -22,6 +22,8 @@
 
 #include <gtest/gtest.h>
 
+#define EXPECT_LONG_DOUBLE_EQ(val1, val2) (val1 == val2)
+
 using namespace eprosima::fastcdr;
 using namespace ::exception;
 
@@ -185,7 +187,7 @@ static void EXPECT_ARRAY_LONG_DOUBLE_EQ(
 {
     for (size_t count = 0; count < size; ++count)
     {
-        EXPECT_TRUE(array1[count] == array2[count]);
+        EXPECT_LONG_DOUBLE_EQ(array1[count], array2[count]);
     }
 }
 
@@ -531,7 +533,7 @@ TEST(CDRResizeTests, LongDouble)
         cdr_des >> ldouble_value;
     });
 
-    EXPECT_TRUE(ldouble_value == ldouble_tt);
+    EXPECT_LONG_DOUBLE_EQ(ldouble_value, ldouble_tt);
 }
 
 TEST(CDRResizeTests, Boolean)
@@ -2447,7 +2449,7 @@ TEST(CDRResizeTests, Complete)
     EXPECT_EQ(longlong_value, longlong_t);
     EXPECT_FLOAT_EQ(float_value, float_tt);
     EXPECT_DOUBLE_EQ(double_value, double_tt);
-    EXPECT_TRUE(ldouble_value == ldouble_tt);
+    EXPECT_LONG_DOUBLE_EQ(ldouble_value, ldouble_tt);
     EXPECT_EQ(bool_value, bool_t);
     EXPECT_EQ(string_value, string_t);
     EXPECT_EQ(wstring_value, wstring_t);
@@ -2861,7 +2863,7 @@ TEST(FastCDRResizeTests, LongDouble)
         cdr_des >> ldouble_value;
     });
 
-    EXPECT_TRUE(ldouble_value == ldouble_tt);
+    EXPECT_LONG_DOUBLE_EQ(ldouble_value, ldouble_tt);
 }
 
 TEST(FastCDRResizeTests, Boolean)
@@ -4777,7 +4779,7 @@ TEST(FastCDRResizeTests, Complete)
     EXPECT_EQ(longlong_value, longlong_t);
     EXPECT_FLOAT_EQ(float_value, float_tt);
     EXPECT_DOUBLE_EQ(double_value, double_tt);
-    EXPECT_TRUE(ldouble_value == ldouble_tt);
+    EXPECT_LONG_DOUBLE_EQ(ldouble_value, ldouble_tt);
     EXPECT_EQ(bool_value, bool_t);
     EXPECT_EQ(string_value, string_t);
     EXPECT_EQ(wstring_value, wstring_t);

--- a/test/cdr/ResizeTest.cpp
+++ b/test/cdr/ResizeTest.cpp
@@ -22,8 +22,6 @@
 
 #include <gtest/gtest.h>
 
-#define EXPECT_LONG_DOUBLE_EQ(val1, val2) (val1 == val2)
-
 using namespace eprosima::fastcdr;
 using namespace ::exception;
 
@@ -187,7 +185,7 @@ static void EXPECT_ARRAY_LONG_DOUBLE_EQ(
 {
     for (size_t count = 0; count < size; ++count)
     {
-        EXPECT_LONG_DOUBLE_EQ(array1[count], array2[count]);
+        EXPECT_TRUE(array1[count] == array2[count]);
     }
 }
 
@@ -533,7 +531,7 @@ TEST(CDRResizeTests, LongDouble)
         cdr_des >> ldouble_value;
     });
 
-    EXPECT_LONG_DOUBLE_EQ(ldouble_value, ldouble_tt);
+    EXPECT_TRUE(ldouble_value == ldouble_tt);
 }
 
 TEST(CDRResizeTests, Boolean)
@@ -2449,7 +2447,7 @@ TEST(CDRResizeTests, Complete)
     EXPECT_EQ(longlong_value, longlong_t);
     EXPECT_FLOAT_EQ(float_value, float_tt);
     EXPECT_DOUBLE_EQ(double_value, double_tt);
-    EXPECT_LONG_DOUBLE_EQ(ldouble_value, ldouble_tt);
+    EXPECT_TRUE(ldouble_value == ldouble_tt);
     EXPECT_EQ(bool_value, bool_t);
     EXPECT_EQ(string_value, string_t);
     EXPECT_EQ(wstring_value, wstring_t);
@@ -2863,7 +2861,7 @@ TEST(FastCDRResizeTests, LongDouble)
         cdr_des >> ldouble_value;
     });
 
-    EXPECT_LONG_DOUBLE_EQ(ldouble_value, ldouble_tt);
+    EXPECT_TRUE(ldouble_value == ldouble_tt);
 }
 
 TEST(FastCDRResizeTests, Boolean)
@@ -4779,7 +4777,7 @@ TEST(FastCDRResizeTests, Complete)
     EXPECT_EQ(longlong_value, longlong_t);
     EXPECT_FLOAT_EQ(float_value, float_tt);
     EXPECT_DOUBLE_EQ(double_value, double_tt);
-    EXPECT_LONG_DOUBLE_EQ(ldouble_value, ldouble_tt);
+    EXPECT_TRUE(ldouble_value == ldouble_tt);
     EXPECT_EQ(bool_value, bool_t);
     EXPECT_EQ(string_value, string_t);
     EXPECT_EQ(wstring_value, wstring_t);

--- a/test/cdr/ResizeTest.cpp
+++ b/test/cdr/ResizeTest.cpp
@@ -182,8 +182,7 @@ static void EXPECT_LONG_DOUBLE_EQ(
         const long double val1,
         const long double val2)
 {
-	static_cast<void>(val1);
-	static_cast<void>(val2);
+    EXPECT_TRUE(val1 == val2);
 }
 
 static void EXPECT_ARRAY_LONG_DOUBLE_EQ(

--- a/test/cdr/SimpleTest.cpp
+++ b/test/cdr/SimpleTest.cpp
@@ -25,6 +25,8 @@
 
 #include <gtest/gtest.h>
 
+#define EXPECT_LONG_DOUBLE_EQ(val1, val2) (val1 == val2)
+
 using namespace eprosima::fastcdr;
 using namespace ::exception;
 
@@ -199,7 +201,7 @@ static void EXPECT_ARRAY_LONG_DOUBLE_EQ(
 {
     for (size_t count = 0; count < size; ++count)
     {
-        EXPECT_TRUE(array1[count] == array2[count]);
+        EXPECT_LONG_DOUBLE_EQ(array1[count], array2[count]);
     }
 }
 
@@ -2135,7 +2137,7 @@ TEST(CDRTests, Complete)
     EXPECT_EQ(longlong_value, longlong_t);
     EXPECT_FLOAT_EQ(float_value, float_tt);
     EXPECT_DOUBLE_EQ(double_value, double_tt);
-    EXPECT_TRUE(ldouble_value == ldouble_tt);
+    EXPECT_LONG_DOUBLE_EQ(ldouble_value, ldouble_tt);
     EXPECT_EQ(bool_value, bool_t);
     EXPECT_EQ(string_value, string_t);
     EXPECT_EQ(wstring_value, wstring_t);
@@ -2768,7 +2770,7 @@ TEST(FastCDRTests, LongDouble)
         cdr_des >> ldouble_value;
     });
 
-    EXPECT_TRUE(ldouble_value == ldouble_tt);
+    EXPECT_LONG_DOUBLE_EQ(ldouble_value, ldouble_tt);
 
     // Check bad case without space
     char buffer_bad[1];
@@ -6536,7 +6538,7 @@ TEST(FastCDRTests, Complete)
     EXPECT_EQ(longlong_value, longlong_t);
     EXPECT_FLOAT_EQ(float_value, float_tt);
     EXPECT_DOUBLE_EQ(double_value, double_tt);
-    EXPECT_TRUE(ldouble_value == ldouble_tt);
+    EXPECT_LONG_DOUBLE_EQ(ldouble_value, ldouble_tt);
     EXPECT_EQ(bool_value, bool_t);
     EXPECT_EQ(string_value, string_t);
     EXPECT_EQ(wstring_value, wstring_t);

--- a/test/cdr/SimpleTest.cpp
+++ b/test/cdr/SimpleTest.cpp
@@ -25,8 +25,6 @@
 
 #include <gtest/gtest.h>
 
-#define EXPECT_LONG_DOUBLE_EQ(val1, val2) (val1 == val2)
-
 using namespace eprosima::fastcdr;
 using namespace ::exception;
 
@@ -201,7 +199,7 @@ static void EXPECT_ARRAY_LONG_DOUBLE_EQ(
 {
     for (size_t count = 0; count < size; ++count)
     {
-        EXPECT_LONG_DOUBLE_EQ(array1[count], array2[count]);
+        EXPECT_TRUE(array1[count] == array2[count]);
     }
 }
 
@@ -2137,7 +2135,7 @@ TEST(CDRTests, Complete)
     EXPECT_EQ(longlong_value, longlong_t);
     EXPECT_FLOAT_EQ(float_value, float_tt);
     EXPECT_DOUBLE_EQ(double_value, double_tt);
-    EXPECT_LONG_DOUBLE_EQ(ldouble_value, ldouble_tt);
+    EXPECT_TRUE(ldouble_value == ldouble_tt);
     EXPECT_EQ(bool_value, bool_t);
     EXPECT_EQ(string_value, string_t);
     EXPECT_EQ(wstring_value, wstring_t);
@@ -2770,7 +2768,7 @@ TEST(FastCDRTests, LongDouble)
         cdr_des >> ldouble_value;
     });
 
-    EXPECT_LONG_DOUBLE_EQ(ldouble_value, ldouble_tt);
+    EXPECT_TRUE(ldouble_value == ldouble_tt);
 
     // Check bad case without space
     char buffer_bad[1];
@@ -6538,7 +6536,7 @@ TEST(FastCDRTests, Complete)
     EXPECT_EQ(longlong_value, longlong_t);
     EXPECT_FLOAT_EQ(float_value, float_tt);
     EXPECT_DOUBLE_EQ(double_value, double_tt);
-    EXPECT_LONG_DOUBLE_EQ(ldouble_value, ldouble_tt);
+    EXPECT_TRUE(ldouble_value == ldouble_tt);
     EXPECT_EQ(bool_value, bool_t);
     EXPECT_EQ(string_value, string_t);
     EXPECT_EQ(wstring_value, wstring_t);

--- a/test/cdr/SimpleTest.cpp
+++ b/test/cdr/SimpleTest.cpp
@@ -196,8 +196,7 @@ static void EXPECT_LONG_DOUBLE_EQ(
         const long double val1,
         const long double val2)
 {
-	static_cast<void>(val1);
-	static_cast<void>(val2);
+    EXPECT_TRUE(val1 == val2);
 }
 
 static void EXPECT_ARRAY_LONG_DOUBLE_EQ(

--- a/test/cdr/SimpleTest.cpp
+++ b/test/cdr/SimpleTest.cpp
@@ -25,8 +25,6 @@
 
 #include <gtest/gtest.h>
 
-#define EXPECT_LONG_DOUBLE_EQ(val1, val2) (val1 == val2)
-
 using namespace eprosima::fastcdr;
 using namespace ::exception;
 
@@ -192,6 +190,14 @@ static void EXPECT_ARRAY_DOUBLE_EQ(
     {
         EXPECT_DOUBLE_EQ(array1[count], array2[count]);
     }
+}
+
+static void EXPECT_LONG_DOUBLE_EQ(
+        const long double val1,
+        const long double val2)
+{
+	static_cast<void>(val1);
+	static_cast<void>(val2);
 }
 
 static void EXPECT_ARRAY_LONG_DOUBLE_EQ(


### PR DESCRIPTION
When building the tests with g++ 13.2.0, it complains that the EXPECT_LONG_DOUBLE_EQ macro has no effect. That ends up being true; because it is just a x == y, with no EXPECT statement around it, it actually does nothing.

Here, I just remove this macro because it is unnecessary; we can just do EXPECT_TRUE(x == y) and get the same effect with less code.

This is targeted at the 2.2.x branch because that is what we are using in ROS 2, but this applies equally to the master branch.