### PR TITLE
[20893] Extend mirror workflow to also mirror in major branches

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -3,8 +3,10 @@ on:
   push:
     branches:
       - 'master'
+      - '1.1.x'
 jobs:
-  mirror_job:
+  mirror_job_master:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     name: Mirror master branch to API & ABI compatible minor version branches
     strategy:
@@ -12,6 +14,7 @@ jobs:
       matrix:
         dest_branch:
           - '2.2.x'
+          - '2.x'
     steps:
     - name: Mirror action step
       id: mirror
@@ -19,4 +22,21 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         source: 'master'
+        dest: ${{ matrix.dest_branch }}
+  mirror_job_1_x:
+    if: github.ref == 'refs/heads/1.1.x'
+    runs-on: ubuntu-latest
+    name: Mirror master branch to API & ABI compatible minor version branches
+    strategy:
+      fail-fast: false
+      matrix:
+        dest_branch:
+          - '1.x'
+    steps:
+    - name: Mirror action step
+      id: mirror
+      uses: eProsima/eProsima-CI/external/mirror-branch-action@v0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        source: '1.1.x'
         dest: ${{ matrix.dest_branch }}


### PR DESCRIPTION
This PR extends the mirror workflow so that:

1. PRs merged in `master` are mirrored both in `2.2.x` and `2.x` branches
2. PRs merged in `1.1.x` (latest 1.x) are mirrored in `1.x` branch

This way, we can keep up-to-date `X.x` branches corresponding to head of major versions