### PR TITLE
[21556] Bugfix: clear map before deserializing with string as values in XCRv1

### DIFF
--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -2024,6 +2024,8 @@ public:
 
             deserialize(sequence_length);
 
+            map_t.clear();
+
             try
             {
                 for (uint32_t i = 0; i < sequence_length; ++i)

--- a/test/cdr/SimpleTest.cpp
+++ b/test/cdr/SimpleTest.cpp
@@ -2251,6 +2251,34 @@ TEST(CDRTests, Complete)
     free(c_wstring_value);
 }
 
+// Regression test for Fast DDS issue #5136
+// A non-empty map should be cleared before deserializing in XCDRv1
+TEST(CDRTests, DeserializeIntoANonEmptyMapInXCDRv1)
+{
+    char buffer[14] =
+    {
+        0x00, 0x00, 0x00, 0x01,  // Map length
+        0x00, 0x02,              // Key
+        0x00, 0x00,              // Alignment
+        0x00, 0x00, 0x00, 0x01,  // Length
+        65,  0x00                // 'a'
+    };
+
+    std::map<uint16_t, std::string> initialized_map{
+        {1, "a"}
+    };
+
+    FastBuffer cdr_buffer(buffer, 14);
+    Cdr cdr_ser_map(
+        cdr_buffer,
+        eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS,
+        XCDRv1);
+
+    // Deserialization in a non-empty map
+    cdr_ser_map >> initialized_map;
+    ASSERT_EQ(initialized_map.size(), 1);
+}
+
 TEST(FastCDRTests, Octet)
 {
     // Check good case.

--- a/test/cdr/SimpleTest.cpp
+++ b/test/cdr/SimpleTest.cpp
@@ -2261,7 +2261,7 @@ TEST(CDRTests, DeserializeIntoANonEmptyMapInXCDRv1)
         0x00, 0x02,              // Key
         0x00, 0x00,              // Alignment
         0x00, 0x00, 0x00, 0x01,  // Length
-        65,  0x00                // 'a'
+        65,  0x00                // 'A'
     };
 
     std::map<uint16_t, std::string> initialized_map{
@@ -2276,7 +2276,8 @@ TEST(CDRTests, DeserializeIntoANonEmptyMapInXCDRv1)
 
     // Deserialization in a non-empty map
     cdr_ser_map >> initialized_map;
-    ASSERT_EQ(initialized_map.size(), 1);
+    ASSERT_EQ(initialized_map.size(), 1u);
+    ASSERT_EQ(initialized_map.at(2), "A");
 }
 
 TEST(FastCDRTests, Octet)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description

A `map<T, string>` was not being cleared before deserializing in `XCDRv1`. Test and fix included. Thanks @fschoenm for the report and @MiguelCompany for the analysis.

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.2.x 1.0.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes eProsima/Fast-DDS/issues/5136

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: CI pass and failing tests are unrelated with the changes.
