### PR TITLE
[21619] Fix C2512 compile error with Visual Studio 2015

### DIFF
--- a/include/fastcdr/xcdr/detail/optional.hpp
+++ b/include/fastcdr/xcdr/detail/optional.hpp
@@ -47,7 +47,7 @@ struct optional_storage
 
 /* *INDENT-OFF* */
 template<class T>
-struct optional_storage<T, typename std::enable_if<std::is_trivially_destructible<T>{}>::type>
+struct optional_storage<T, typename std::enable_if<std::is_trivially_destructible<T>::value>::type>
 {
     union
     {


### PR DESCRIPTION
Fixes a compile error with Visual Studio 2015.

## Description

Steps to reproduce (tested on current `master`)

```
git clone <repo> && cd <repo>
cmake -G"Visual Studio 14 2015 Win64" ..
cmake --build .
```

Will result in the following output

```
 D:\projects\Fast-CDR\build>cmake -G"Visual Studio 14 2015 Win64" ..
-- Setting build type to 'Release' as none was specified.
-- Tests not compiled by default
-- Selecting Windows SDK version 10.0.14393.0 to target Windows 10.0.22631.
-- The CXX compiler identification is MSVC 19.0.24215.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/x86_amd64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring Fast CDR
-- Version: 2.2.3
-- Enforced cxx_std_11 CMake feature
-- Looking for C++ include sys/types.h
-- Looking for C++ include sys/types.h - found
-- Looking for C++ include stdint.h
-- Looking for C++ include stdint.h - found
-- Looking for C++ include stddef.h
-- Looking for C++ include stddef.h - found
-- Check size of long double
-- Check size of long double - done
-- Check size of __float128
-- Check size of __float128 - failed
-- The C compiler identification is MSVC 19.0.24215.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/x86_amd64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done (7.9s)
-- Generating done (0.0s)
-- Build files have been written to: D:/projects/Fast-CDR/build

(viewer-env-win) D:\projects\Fast-CDR\build>cmake --build .
Microsoft (R) Build Engine version 14.0.27530.0
Copyright (C) Microsoft Corporation. All rights reserved.

  Checking Build System
  Building Custom Rule D:/projects/Fast-CDR/src/cpp/CMakeLists.txt
  Cdr.cpp
d:\projects\fast-cdr\include\fastcdr\xcdr\detail/optional.hpp(50): error C2512: 'std::is_trivially_destructible<_Ty>': no appropriate default constructor available [D:\projects\Fast-CDR\build\src\cpp\fastcdr.vcxproj]
  d:\projects\fast-cdr\include\fastcdr\xcdr\detail/optional.hpp(50): note: The target type has no constructors
d:\projects\fast-cdr\include\fastcdr\xcdr\detail/optional.hpp(50): error C2039: 'type': is not a member of 'std::enable_if<false,_Ty>' [D:\projects\Fast-CDR\build\src\cpp\fastcdr.vcxproj]
          with
          [
              _Ty=void
          ]
  C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\type_traits(1877): note: see declaration of 'std::enable_if<false,_Ty>'
          with
          [
              _Ty=void
          ]
d:\projects\fast-cdr\include\fastcdr\xcdr\detail/optional.hpp(50): error C2146: syntax error: missing '>' before identifier 'type' [D:\projects\Fast-CDR\build\src\cpp\fastcdr.vcxproj]
D:\projects\Fast-CDR\src\cpp\Cdr.cpp(2543): warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning) [D:\projects\Fast-CDR\build\src\cpp\fastcdr.vcxproj]
D:\projects\Fast-CDR\src\cpp\Cdr.cpp(3075): warning C4800: 'uint32_t': forcing value to bool 'true' or 'false' (performance warning) [D:\projects\Fast-CDR\build\src\cpp\fastcdr.vcxproj]
  CdrSizeCalculator.cpp
d:\projects\fast-cdr\include\fastcdr\xcdr\detail/optional.hpp(50): error C2512: 'std::is_trivially_destructible<_Ty>': no appropriate default constructor available [D:\projects\Fast-CDR\build\src\cpp\fastcdr.vcxproj]
  d:\projects\fast-cdr\include\fastcdr\xcdr\detail/optional.hpp(50): note: The target type has no constructors
d:\projects\fast-cdr\include\fastcdr\xcdr\detail/optional.hpp(50): error C2039: 'type': is not a member of 'std::enable_if<false,_Ty>' [D:\projects\Fast-CDR\build\src\cpp\fastcdr.vcxproj]
          with
          [
              _Ty=void
          ]
  C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\type_traits(1877): note: see declaration of 'std::enable_if<false,_Ty>'
          with
          [
              _Ty=void
          ]
d:\projects\fast-cdr\include\fastcdr\xcdr\detail/optional.hpp(50): error C2146: syntax error: missing '>' before identifier 'type' [D:\projects\Fast-CDR\build\src\cpp\fastcdr.vcxproj]
  FastCdr.cpp
  FastBuffer.cpp
  BadOptionalAccessException.cpp
  BadParamException.cpp
  Exception.cpp
  LockedExternalAccessException.cpp
  NotEnoughMemoryException.cpp
  Generating Code...
```

The fix uses `std::is_trivially_destructible<T>::value` instead of `std::is_trivially_destructible<T>{}` and relying on `operator bool`.