### PR TITLE
[21785] Fix encoding/decoding when inner structure has different extensibility

### DIFF
--- a/include/fastcdr/CdrSizeCalculator.hpp
+++ b/include/fastcdr/CdrSizeCalculator.hpp
@@ -1166,7 +1166,9 @@ public:
                 0 < calculated_size)
         {
 
-            if (8 < calculated_size)
+            if (8 < calculated_size ||
+                    (1 != calculated_size && 2 != calculated_size && 4 != calculated_size &&
+                    8 != calculated_size))
             {
                 extra_size = 8; // Long EMHEADER.
                 if (NO_SERIALIZED_MEMBER_SIZE != serialized_member_size_)

--- a/test/xcdr/CMakeLists.txt
+++ b/test/xcdr/CMakeLists.txt
@@ -19,6 +19,7 @@ set(XCDR_TEST_SOURCE
     appendable.cpp
     basic_types.cpp
     external.cpp
+    final.cpp
     mutable.cpp
     optional.cpp
     xcdrv1.cpp

--- a/test/xcdr/appendable.cpp
+++ b/test/xcdr/appendable.cpp
@@ -256,6 +256,99 @@ void deserialize(
 } // namespace fastcdr
 } // namespace eprosima
 
+struct ApInnerStructure
+{
+public:
+
+    ApInnerStructure() = default;
+
+    ApInnerStructure(
+            eprosima::fastcdr::EncodingAlgorithmFlag e1,
+            eprosima::fastcdr::EncodingAlgorithmFlag e2
+            )
+        : enc_xcdrv1(e1)
+        , enc_xcdrv2(e2)
+    {
+    }
+
+    ApInnerStructure(
+            eprosima::fastcdr::EncodingAlgorithmFlag e1,
+            eprosima::fastcdr::EncodingAlgorithmFlag e2,
+            uint8_t value
+            )
+        : value1(value)
+        , enc_xcdrv1(e1)
+        , enc_xcdrv2(e2)
+    {
+    }
+
+    bool operator ==(
+            const ApInnerStructure& other) const
+    {
+        return value1 == other.value1 &&
+               value2.has_value() == other.value2.has_value() &&
+               (!value2.has_value() || value2.value() == other.value2.value());
+    }
+
+    //! First being serialized.
+    uint32_t value1 {0};
+
+    //! Second being serialized.
+    eprosima::fastcdr::optional<uint32_t> value2;
+
+    eprosima::fastcdr::EncodingAlgorithmFlag enc_xcdrv1 {eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR};
+
+    eprosima::fastcdr::EncodingAlgorithmFlag enc_xcdrv2 {eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2};
+};
+
+namespace eprosima {
+namespace fastcdr {
+
+template<>
+void serialize(
+        Cdr& cdr,
+        const ApInnerStructure& data)
+{
+    Cdr::state current_status(cdr);
+    cdr.begin_serialize_type(current_status, cdr.get_cdr_version() == eprosima::fastcdr::CdrVersion::XCDRv1
+                             ? data.enc_xcdrv1
+                             : data.enc_xcdrv2);
+    cdr << MemberId(0) << data.value1;
+    cdr << MemberId(1) << data.value2;
+    cdr.end_serialize_type(current_status);
+}
+
+template<>
+void deserialize(
+        Cdr& cdr,
+        ApInnerStructure& data)
+{
+    cdr.deserialize_type(cdr.get_cdr_version() == eprosima::fastcdr::CdrVersion::XCDRv1
+                         ? data.enc_xcdrv1
+                         : data.enc_xcdrv2,
+            [&data](Cdr& cdr_inner, const MemberId& mid) -> bool
+            {
+                bool ret_value {true};
+                switch (mid.id)
+                {
+                    case 0:
+                        cdr_inner >> data.value1;
+                        break;
+                    case 1:
+                        cdr_inner >> data.value2;
+                        break;
+                    default:
+                        ret_value = false;
+                        break;
+                }
+
+                return ret_value;
+            });
+}
+
+} // namespace fastcdr
+} // namespace eprosima
+
 /*!
  * @test Test an appendable structure where the encoded version has more members that the decoded one.
  * @code{.idl}
@@ -955,6 +1048,262 @@ TEST_P(XCdrAppendableTest, inner_mutable)
     ASSERT_EQ(enc_state_end, dec_state_end);
     ASSERT_EQ(value, dvalue);
     ASSERT_EQ(value2, dvalue2);
+    //}
+}
+
+/*!
+ * @test Test an inner final structure inside a appendable structure.
+ * @code{.idl}
+ * @final
+ * struct InnerFinalStructure
+ * {
+ *     @id(0)
+ *     unsigned long value1;
+ *     @id(1) @optional
+ *     unsigned long value2;
+ * };
+ *
+ * @appendable
+ * struct AppendableWithInnerFinalStruct
+ * {
+ *     @id(1)
+ *     unsigned long value1;
+ *     @id(2)
+ *     InnerFinalStructure value2;
+ * };
+ * @endcode
+ */
+TEST_P(XCdrAppendableTest, inner_final_structure)
+{
+    constexpr uint8_t ival {0xCD};
+
+    //{ Defining expected XCDR streams
+    XCdrStreamValues expected_streams;
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00, 0x01, 0x00, 0x00, // ShortMemberHeader (optional)
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        ival, 0x00, 0x00, 0x00, // ULong
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x01, 0x00, 0x00, 0x00, // ShortMemberHeader (optional)
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x09, // DHEADER
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00,                   // Optional not present
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x09, 0x00, 0x00, 0x00, // DHEADER
+        ival, 0x00, 0x00, 0x00, // ULong
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x00,                   // Optional not present
+    };
+    //}
+
+    EncodingAlgorithmFlag encoding = std::get<0>(GetParam());
+    Cdr::Endianness endianness = std::get<1>(GetParam());
+
+    //{ Prepare buffer
+    uint8_t tested_stream = 0 + encoding + endianness;
+    auto buffer =
+            std::unique_ptr<char, void (*)(
+        void*)>{reinterpret_cast<char*>(calloc(expected_streams[tested_stream].size(), sizeof(char))), free};
+    FastBuffer fast_buffer(buffer.get(), expected_streams[tested_stream].size());
+    Cdr cdr(fast_buffer, endianness, get_version_from_algorithm(encoding));
+    //}
+
+    //{ Encode
+    uint32_t value1 {ival};
+    ApInnerStructure value2 {eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2, ival};
+    cdr.set_encoding_flag(encoding);
+    cdr.serialize_encapsulation();
+    Cdr::state enc_state(cdr);
+    cdr.begin_serialize_type(enc_state, encoding);
+    cdr << MemberId(1) << value1;
+    cdr << MemberId(2) << value2;
+    cdr.end_serialize_type(enc_state);
+    Cdr::state enc_state_end(cdr);
+    //}
+
+    //{ Test encoded content
+    ASSERT_EQ(cdr.get_serialized_data_length(), expected_streams[tested_stream].size());
+    ASSERT_EQ(0, memcmp(buffer.get(), expected_streams[tested_stream].data(),
+            expected_streams[tested_stream].size()));
+    //}
+
+    //{ Decoding
+    uint32_t dvalue1 {0};
+    ApInnerStructure dvalue2 {eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                              eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2, ival};
+    cdr.reset();
+    cdr.read_encapsulation();
+    ASSERT_EQ(cdr.get_encoding_flag(), encoding);
+    ASSERT_EQ(cdr.endianness(), endianness);
+    cdr.deserialize_type(encoding, [&](Cdr& cdr_inner, const MemberId& mid)->bool
+            {
+                bool ret_value {true};
+
+                switch (mid.id)
+                {
+                    case 0:
+                        cdr_inner >> dvalue1;
+                        break;
+                    case 1:
+                        cdr_inner >> dvalue2;
+                        break;
+                    default:
+                        ret_value = false;
+                        break;
+                }
+
+                return ret_value;
+            });
+    ASSERT_EQ(value1, dvalue1);
+    ASSERT_EQ(value2, dvalue2);
+    Cdr::state dec_state_end(cdr);
+    ASSERT_EQ(enc_state_end, dec_state_end);
+    //}
+}
+
+/*!
+ * @test Test an inner mutable structure inside a appendable structure.
+ * @code{.idl}
+ * @mutable
+ * struct InnerMutableStructure
+ * {
+ *     @id(0)
+ *     unsigned long value1;
+ *     @id(1) @optional
+ *     unsigned long value2;
+ * };
+ *
+ * @appendable
+ * struct AppendableWithInnerMutableStruct
+ * {
+ *     @id(1)
+ *     unsigned long value1;
+ *     @id(2)
+ *     InnerMutableStructure value2;
+ * };
+ * @endcode
+ */
+TEST_P(XCdrAppendableTest, inner_mutable_structure)
+{
+    constexpr uint8_t ival {0xCD};
+
+    //{ Defining expected XCDR streams
+    XCdrStreamValues expected_streams;
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00, 0x00, 0x00, 0x04, // ShortMemberHeader
+        0x00, 0x00, 0x00, ival, // ULong
+        0x3F, 0x02, 0x00, 0x00, // Sentinel
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x00, 0x00, 0x04, 0x00, // ShortMemberHeader
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x02, 0x3F, 0x00, 0x00, // Sentinel
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x10, // DHEADER
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00, 0x00, 0x00, 0x08, // DHEADER
+        0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
+        0x00, 0x00, 0x00, ival, // ULong
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x10, 0x00, 0x00, 0x00, // DHEADER
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x08, 0x00, 0x00, 0x00, // DHEADER
+        0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
+        ival, 0x00, 0x00, 0x00, // ULong
+    };
+    //}
+
+    EncodingAlgorithmFlag encoding = std::get<0>(GetParam());
+    Cdr::Endianness endianness = std::get<1>(GetParam());
+
+    //{ Prepare buffer
+    uint8_t tested_stream = 0 + encoding + endianness;
+    auto buffer =
+            std::unique_ptr<char, void (*)(
+        void*)>{reinterpret_cast<char*>(calloc(expected_streams[tested_stream].size(), sizeof(char))), free};
+    FastBuffer fast_buffer(buffer.get(), expected_streams[tested_stream].size());
+    Cdr cdr(fast_buffer, endianness, get_version_from_algorithm(encoding));
+    //}
+
+    //{ Encode
+    uint32_t value1 {ival};
+    ApInnerStructure value2 {eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR,
+                             eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2, ival};
+    cdr.set_encoding_flag(encoding);
+    cdr.serialize_encapsulation();
+    Cdr::state enc_state(cdr);
+    cdr.begin_serialize_type(enc_state, encoding);
+    cdr << MemberId(1) << value1;
+    cdr << MemberId(2) << value2;
+    cdr.end_serialize_type(enc_state);
+    Cdr::state enc_state_end(cdr);
+    //}
+
+    //{ Test encoded content
+    ASSERT_EQ(cdr.get_serialized_data_length(), expected_streams[tested_stream].size());
+    ASSERT_EQ(0, memcmp(buffer.get(), expected_streams[tested_stream].data(),
+            expected_streams[tested_stream].size()));
+    //}
+
+    //{ Decoding
+    uint32_t dvalue1 {0};
+    ApInnerStructure dvalue2 {eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR,
+                              eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2, ival};
+    cdr.reset();
+    cdr.read_encapsulation();
+    ASSERT_EQ(cdr.get_encoding_flag(), encoding);
+    ASSERT_EQ(cdr.endianness(), endianness);
+    cdr.deserialize_type(encoding, [&](Cdr& cdr_inner, const MemberId& mid)->bool
+            {
+                bool ret_value {true};
+
+                switch (mid.id)
+                {
+                    case 0:
+                        cdr_inner >> dvalue1;
+                        break;
+                    case 1:
+                        cdr_inner >> dvalue2;
+                        break;
+                    default:
+                        ret_value = false;
+                        break;
+                }
+
+                return ret_value;
+            });
+    ASSERT_EQ(value1, dvalue1);
+    ASSERT_EQ(value2, dvalue2);
+    Cdr::state dec_state_end(cdr);
+    ASSERT_EQ(enc_state_end, dec_state_end);
     //}
 }
 

--- a/test/xcdr/final.cpp
+++ b/test/xcdr/final.cpp
@@ -1,0 +1,392 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <array>
+#include <memory>
+#include <tuple>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <fastcdr/Cdr.h>
+#include "utility.hpp"
+
+using namespace eprosima::fastcdr;
+
+using XCdrStreamValues =
+        std::array<std::vector<uint8_t>,
+                1 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS>;
+
+
+class XCdrFinalTest : public ::testing::TestWithParam< std::tuple<EncodingAlgorithmFlag, Cdr::Endianness>>
+{
+};
+
+struct FiInnerStructure
+{
+public:
+
+    FiInnerStructure() = default;
+
+    FiInnerStructure(
+            eprosima::fastcdr::EncodingAlgorithmFlag e1,
+            eprosima::fastcdr::EncodingAlgorithmFlag e2
+            )
+        : enc_xcdrv1(e1)
+        , enc_xcdrv2(e2)
+    {
+    }
+
+    FiInnerStructure(
+            eprosima::fastcdr::EncodingAlgorithmFlag e1,
+            eprosima::fastcdr::EncodingAlgorithmFlag e2,
+            uint8_t value
+            )
+        : value1(value)
+        , enc_xcdrv1(e1)
+        , enc_xcdrv2(e2)
+    {
+    }
+
+    bool operator ==(
+            const FiInnerStructure& other) const
+    {
+        return value1 == other.value1 &&
+               value2.has_value() == other.value2.has_value() &&
+               (!value2.has_value() || value2.value() == other.value2.value());
+    }
+
+    //! First being serialized.
+    uint32_t value1 {0};
+
+    //! Second being serialized.
+    eprosima::fastcdr::optional<uint32_t> value2;
+
+    eprosima::fastcdr::EncodingAlgorithmFlag enc_xcdrv1 {eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR};
+
+    eprosima::fastcdr::EncodingAlgorithmFlag enc_xcdrv2 {eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2};
+};
+
+namespace eprosima {
+namespace fastcdr {
+
+template<>
+void serialize(
+        Cdr& cdr,
+        const FiInnerStructure& data)
+{
+    Cdr::state current_status(cdr);
+    cdr.begin_serialize_type(current_status, cdr.get_cdr_version() == eprosima::fastcdr::CdrVersion::XCDRv1
+                             ? data.enc_xcdrv1
+                             : data.enc_xcdrv2);
+    cdr << MemberId(0) << data.value1;
+    cdr << MemberId(1) << data.value2;
+    cdr.end_serialize_type(current_status);
+}
+
+template<>
+void deserialize(
+        Cdr& cdr,
+        FiInnerStructure& data)
+{
+    cdr.deserialize_type(cdr.get_cdr_version() == eprosima::fastcdr::CdrVersion::XCDRv1
+                         ? data.enc_xcdrv1
+                         : data.enc_xcdrv2,
+            [&data](Cdr& cdr_inner, const MemberId& mid) -> bool
+            {
+                bool ret_value {true};
+                switch (mid.id)
+                {
+                    case 0:
+                        cdr_inner >> data.value1;
+                        break;
+                    case 1:
+                        cdr_inner >> data.value2;
+                        break;
+                    default:
+                        ret_value = false;
+                        break;
+                }
+
+                return ret_value;
+            });
+}
+
+} // namespace fastcdr
+} // namespace eprosima
+
+/*!
+ * @test Test an inner appendable structure inside a final structure.
+ * @code{.idl}
+ * @appendable
+ * struct InnerAppendableStructure
+ * {
+ *     @id(0)
+ *     unsigned long value1;
+ *     @id(1) @optional
+ *     unsigned long value2;
+ * };
+ *
+ * @final
+ * struct FinalWithInnerAppendableStruct
+ * {
+ *     @id(1)
+ *     unsigned long value1;
+ *     @id(2)
+ *     InnerAppendableStructure value2;
+ * };
+ * @endcode
+ */
+TEST_P(XCdrFinalTest, inner_appendable_structure)
+{
+    constexpr uint8_t ival {0xCD};
+
+    //{ Defining expected XCDR streams
+    XCdrStreamValues expected_streams;
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00, 0x01, 0x00, 0x00, // ShortMemberHeader (optional)
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        ival, 0x00, 0x00, 0x00, // ULong
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x01, 0x00, 0x00, 0x00, // ShortMemberHeader (optional)
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00, 0x00, 0x00, 0x05, // DHEADER
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00,                   // Optional not present
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x05, 0x00, 0x00, 0x00, // DHEADER
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x00,                   // Optional not present
+    };
+    //}
+
+    EncodingAlgorithmFlag encoding = std::get<0>(GetParam());
+    Cdr::Endianness endianness = std::get<1>(GetParam());
+
+    //{ Prepare buffer
+    uint8_t tested_stream = 0 + encoding + endianness;
+    auto buffer =
+            std::unique_ptr<char, void (*)(
+        void*)>{reinterpret_cast<char*>(calloc(expected_streams[tested_stream].size(), sizeof(char))), free};
+    FastBuffer fast_buffer(buffer.get(), expected_streams[tested_stream].size());
+    Cdr cdr(fast_buffer, endianness, get_version_from_algorithm(encoding));
+    //}
+
+    //{ Encode
+    uint32_t value1 {ival};
+    FiInnerStructure value2 {eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2, ival};
+    cdr.set_encoding_flag(encoding);
+    cdr.serialize_encapsulation();
+    Cdr::state enc_state(cdr);
+    cdr.begin_serialize_type(enc_state, encoding);
+    cdr << MemberId(1) << value1;
+    cdr << MemberId(2) << value2;
+    cdr.end_serialize_type(enc_state);
+    Cdr::state enc_state_end(cdr);
+    //}
+
+    //{ Test encoded content
+    ASSERT_EQ(cdr.get_serialized_data_length(), expected_streams[tested_stream].size());
+    ASSERT_EQ(0, memcmp(buffer.get(), expected_streams[tested_stream].data(),
+            expected_streams[tested_stream].size()));
+    //}
+
+    //{ Decoding
+    uint32_t dvalue1 {0};
+    FiInnerStructure dvalue2 {eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                              eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2, ival};
+    cdr.reset();
+    cdr.read_encapsulation();
+    ASSERT_EQ(cdr.get_encoding_flag(), encoding);
+    ASSERT_EQ(cdr.endianness(), endianness);
+    cdr.deserialize_type(encoding, [&](Cdr& cdr_inner, const MemberId& mid)->bool
+            {
+                bool ret_value {true};
+
+                switch (mid.id)
+                {
+                    case 0:
+                        cdr_inner >> dvalue1;
+                        break;
+                    case 1:
+                        cdr_inner >> dvalue2;
+                        break;
+                    default:
+                        ret_value = false;
+                        break;
+                }
+
+                return ret_value;
+            });
+    ASSERT_EQ(value1, dvalue1);
+    ASSERT_EQ(value2, dvalue2);
+    Cdr::state dec_state_end(cdr);
+    ASSERT_EQ(enc_state_end, dec_state_end);
+    //}
+}
+
+/*!
+ * @test Test an inner mutable structure inside a final structure.
+ * @code{.idl}
+ * @mutable
+ * struct InnerMutableStructure
+ * {
+ *     @id(0)
+ *     unsigned long value1;
+ *     @id(1) @optional
+ *     unsigned long value2;
+ * };
+ *
+ * @final
+ * struct FinalWithInnerMutableStruct
+ * {
+ *     @id(1)
+ *     unsigned long value1;
+ *     @id(2)
+ *     InnerMutableStructure value2;
+ * };
+ * @endcode
+ */
+TEST_P(XCdrFinalTest, inner_mutable_structure)
+{
+    constexpr uint8_t ival {0xCD};
+
+    //{ Defining expected XCDR streams
+    XCdrStreamValues expected_streams;
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00, 0x00, 0x00, 0x04, // ShortMemberHeader
+        0x00, 0x00, 0x00, ival, // ULong
+        0x3F, 0x02, 0x00, 0x00, // Sentinel
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x00, 0x00, 0x04, 0x00, // ShortMemberHeader
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x02, 0x3F, 0x00, 0x00, // Sentinel
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00, 0x00, 0x00, 0x08, // DHEADER
+        0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
+        0x00, 0x00, 0x00, ival, // ULong
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x08, 0x00, 0x00, 0x00, // DHEADER
+        0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
+        ival, 0x00, 0x00, 0x00, // ULong
+    };
+    //}
+
+    EncodingAlgorithmFlag encoding = std::get<0>(GetParam());
+    Cdr::Endianness endianness = std::get<1>(GetParam());
+
+    //{ Prepare buffer
+    uint8_t tested_stream = 0 + encoding + endianness;
+    auto buffer =
+            std::unique_ptr<char, void (*)(
+        void*)>{reinterpret_cast<char*>(calloc(expected_streams[tested_stream].size(), sizeof(char))), free};
+    FastBuffer fast_buffer(buffer.get(), expected_streams[tested_stream].size());
+    Cdr cdr(fast_buffer, endianness, get_version_from_algorithm(encoding));
+    //}
+
+    //{ Encode
+    uint32_t value1 {ival};
+    FiInnerStructure value2 {eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR,
+                             eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2, ival};
+    cdr.set_encoding_flag(encoding);
+    cdr.serialize_encapsulation();
+    Cdr::state enc_state(cdr);
+    cdr.begin_serialize_type(enc_state, encoding);
+    cdr << MemberId(1) << value1;
+    cdr << MemberId(2) << value2;
+    cdr.end_serialize_type(enc_state);
+    Cdr::state enc_state_end(cdr);
+    //}
+
+    //{ Test encoded content
+    ASSERT_EQ(cdr.get_serialized_data_length(), expected_streams[tested_stream].size());
+    ASSERT_EQ(0, memcmp(buffer.get(), expected_streams[tested_stream].data(),
+            expected_streams[tested_stream].size()));
+    //}
+
+    //{ Decoding
+    uint32_t dvalue1 {0};
+    FiInnerStructure dvalue2 {eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR,
+                              eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2, ival};
+    cdr.reset();
+    cdr.read_encapsulation();
+    ASSERT_EQ(cdr.get_encoding_flag(), encoding);
+    ASSERT_EQ(cdr.endianness(), endianness);
+    cdr.deserialize_type(encoding, [&](Cdr& cdr_inner, const MemberId& mid)->bool
+            {
+                bool ret_value {true};
+
+                switch (mid.id)
+                {
+                    case 0:
+                        cdr_inner >> dvalue1;
+                        break;
+                    case 1:
+                        cdr_inner >> dvalue2;
+                        break;
+                    default:
+                        ret_value = false;
+                        break;
+                }
+
+                return ret_value;
+            });
+    ASSERT_EQ(value1, dvalue1);
+    ASSERT_EQ(value2, dvalue2);
+    Cdr::state dec_state_end(cdr);
+    ASSERT_EQ(enc_state_end, dec_state_end);
+    //}
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    XCdrTest,
+    XCdrFinalTest,
+    ::testing::Values(
+        std::make_tuple(EncodingAlgorithmFlag::PLAIN_CDR, Cdr::Endianness::BIG_ENDIANNESS),
+        std::make_tuple(EncodingAlgorithmFlag::PLAIN_CDR, Cdr::Endianness::LITTLE_ENDIANNESS),
+        std::make_tuple(EncodingAlgorithmFlag::PLAIN_CDR2, Cdr::Endianness::BIG_ENDIANNESS),
+        std::make_tuple(EncodingAlgorithmFlag::PLAIN_CDR2, Cdr::Endianness::LITTLE_ENDIANNESS)
+        ));
+

--- a/test/xcdr/mutable.cpp
+++ b/test/xcdr/mutable.cpp
@@ -183,6 +183,81 @@ void deserialize(
 } // namespace fastcdr
 } // namespace eprosima
 
+struct InnerFinalStructure
+{
+public:
+
+    InnerFinalStructure() = default;
+
+    InnerFinalStructure(
+            uint8_t value)
+    {
+        value1 = value;
+    }
+
+    bool operator ==(
+            const InnerFinalStructure& other) const
+    {
+        return value1 == other.value1 &&
+               value2.has_value() == other.value2.has_value() &&
+               (!value2.has_value() || value2.value() == other.value2.value());
+    }
+
+    //! First being serialized.
+    uint32_t value1 {0};
+
+    //! Second being serialized.
+    eprosima::fastcdr::optional<uint32_t> value2;
+};
+
+namespace eprosima {
+namespace fastcdr {
+
+template<>
+void serialize(
+        Cdr& cdr,
+        const InnerFinalStructure& data)
+{
+    Cdr::state current_status(cdr);
+    cdr.begin_serialize_type(current_status, cdr.get_cdr_version() == eprosima::fastcdr::CdrVersion::XCDRv1
+                             ? eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR
+                             : eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
+    cdr << MemberId(3) << data.value1;
+    cdr << MemberId(16) << data.value2;
+    cdr.end_serialize_type(current_status);
+}
+
+template<>
+void deserialize(
+        Cdr& cdr,
+        InnerFinalStructure& data)
+{
+    cdr.deserialize_type(cdr.get_cdr_version() == eprosima::fastcdr::CdrVersion::XCDRv1
+                         ? eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR
+                         : eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2,
+            [&data](Cdr& cdr_inner, const MemberId& mid) -> bool
+            {
+                bool ret_value = true;
+                switch (mid.id)
+                {
+                    case 0:
+                        cdr_inner >> data.value1;
+                        break;
+                    case 1:
+                        cdr_inner >> data.value2;
+                        break;
+                    default:
+                        ret_value = false;
+                        break;
+                }
+
+                return ret_value;
+            });
+}
+
+} // namespace fastcdr
+} // namespace eprosima
+
 /*!
  * @test Test a mutable structure where the encoded version has more members that the decoded one.
  * @code{.idl}
@@ -856,6 +931,142 @@ TEST_P(XCdrMutableTest, inner_unordered_and_less_serialized_elements)
             });
     ASSERT_EQ(value, dvalue1);
     ASSERT_EQ(value, dvalue2);
+    Cdr::state dec_state_end(cdr);
+    ASSERT_EQ(enc_state_end, dec_state_end);
+    //}
+}
+
+/*!
+ * @test Test an inner final structure inside a mutable structure.
+ * @code{.idl}
+ * @final
+ * struct InnerFinalStructure
+ * {
+ *     @id(3)
+ *     unsigned long value1;
+ *     @id(16) @optional
+ *     unsigned long value2;
+ * };
+ *
+ * @mutable
+ * struct MutableWithInnerFinalStruct
+ * {
+ *     @id(1)
+ *     unsigned long value1;
+ *     @id(2)
+ *     InnerFinalStructure value2;
+ * };
+ * @endcode
+ */
+TEST_P(XCdrMutableTest, inner_final_structure)
+{
+    constexpr uint8_t ival {0xCD};
+
+    //{ Defining expected XCDR streams
+    XCdrStreamValues expected_streams;
+    expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x02, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x04, // ShortMemberHeader
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00, 0x02, 0x00, 0x08, // ShortMemberHeader
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00, 0x10, 0x00, 0x00, // ShortMemberHeader (optional)
+        0x3F, 0x02, 0x00, 0x00, // Sentinel
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x03, 0x00, 0x00, // Encapsulation
+        0x01, 0x00, 0x04, 0x00, // ShortMemberHeader
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x02, 0x00, 0x08, 0x00, // ShortMemberHeader
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x10, 0x00, 0x00, 0x00, // ShortMemberHeader
+        0x02, 0x3F, 0x00, 0x00, // Sentinel
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x15, // DHEADER
+        0x20, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
+        0x00, 0x00, 0x00, ival, // ULong
+        0x40, 0x00, 0x00, 0x02, // EMHEADER1(M) with NEXTINT
+        0x00, 0x00, 0x00, 0x05, // NEXTINT
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00,                   // Optional not present
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x15, 0x00, 0x00, 0x00, // DHEADER
+        0x01, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x02, 0x00, 0x00, 0x40, // EMHEADER1(M) with NEXTINT
+        0x05, 0x00, 0x00, 0x00, // NEXTINT
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x00,                   // Optional not present
+    };
+    //}
+
+    EncodingAlgorithmFlag encoding = std::get<0>(GetParam());
+    Cdr::Endianness endianness = std::get<1>(GetParam());
+
+    //{ Prepare buffer
+    uint8_t tested_stream = 0 + encoding + endianness;
+    auto buffer =
+            std::unique_ptr<char, void (*)(
+        void*)>{reinterpret_cast<char*>(calloc(expected_streams[tested_stream].size(), sizeof(char))), free};
+    FastBuffer fast_buffer(buffer.get(), expected_streams[tested_stream].size());
+    Cdr cdr(fast_buffer, endianness, get_version_from_algorithm(encoding));
+    //}
+
+    //{ Encode
+    uint32_t value1 {ival};
+    InnerFinalStructure value2 {ival};
+    cdr.set_encoding_flag(encoding);
+    cdr.serialize_encapsulation();
+    Cdr::state enc_state(cdr);
+    cdr.begin_serialize_type(enc_state, encoding);
+    cdr << MemberId(1) << value1;
+    cdr << MemberId(2) << value2;
+    cdr.end_serialize_type(enc_state);
+    Cdr::state enc_state_end(cdr);
+    //}
+
+    //{ Test encoded content
+    ASSERT_EQ(cdr.get_serialized_data_length(), expected_streams[tested_stream].size());
+    ASSERT_EQ(0, memcmp(buffer.get(), expected_streams[tested_stream].data(),
+            expected_streams[tested_stream].size()));
+    //}
+
+    //{ Decoding
+    uint32_t dvalue1 {0};
+    InnerFinalStructure dvalue2;
+    cdr.reset();
+    cdr.read_encapsulation();
+    ASSERT_EQ(cdr.get_encoding_flag(), encoding);
+    ASSERT_EQ(cdr.endianness(), endianness);
+    cdr.deserialize_type(encoding, [&](Cdr& cdr_inner, const MemberId& mid)->bool
+            {
+                bool ret_value = true;
+
+                switch (mid.id)
+                {
+                    case 1:
+                        cdr_inner >> dvalue1;
+                        break;
+                    case 2:
+                        cdr_inner >> dvalue2;
+                        break;
+                    default:
+                        ret_value = false;
+                        break;
+                }
+
+                return ret_value;
+            });
+    ASSERT_EQ(value1, dvalue1);
+    ASSERT_EQ(value2, dvalue2);
     Cdr::state dec_state_end(cdr);
     ASSERT_EQ(enc_state_end, dec_state_end);
     //}

--- a/test/xcdr/mutable.cpp
+++ b/test/xcdr/mutable.cpp
@@ -183,20 +183,34 @@ void deserialize(
 } // namespace fastcdr
 } // namespace eprosima
 
-struct InnerFinalStructure
+struct MuInnerStructure
 {
 public:
 
-    InnerFinalStructure() = default;
+    MuInnerStructure() = default;
 
-    InnerFinalStructure(
-            uint8_t value)
+    MuInnerStructure(
+            eprosima::fastcdr::EncodingAlgorithmFlag e1,
+            eprosima::fastcdr::EncodingAlgorithmFlag e2
+            )
+        : enc_xcdrv1(e1)
+        , enc_xcdrv2(e2)
     {
-        value1 = value;
+    }
+
+    MuInnerStructure(
+            eprosima::fastcdr::EncodingAlgorithmFlag e1,
+            eprosima::fastcdr::EncodingAlgorithmFlag e2,
+            uint8_t value
+            )
+        : value1(value)
+        , enc_xcdrv1(e1)
+        , enc_xcdrv2(e2)
+    {
     }
 
     bool operator ==(
-            const InnerFinalStructure& other) const
+            const MuInnerStructure& other) const
     {
         return value1 == other.value1 &&
                value2.has_value() == other.value2.has_value() &&
@@ -208,6 +222,10 @@ public:
 
     //! Second being serialized.
     eprosima::fastcdr::optional<uint32_t> value2;
+
+    eprosima::fastcdr::EncodingAlgorithmFlag enc_xcdrv1 {eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR};
+
+    eprosima::fastcdr::EncodingAlgorithmFlag enc_xcdrv2 {eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2};
 };
 
 namespace eprosima {
@@ -216,12 +234,12 @@ namespace fastcdr {
 template<>
 void serialize(
         Cdr& cdr,
-        const InnerFinalStructure& data)
+        const MuInnerStructure& data)
 {
     Cdr::state current_status(cdr);
     cdr.begin_serialize_type(current_status, cdr.get_cdr_version() == eprosima::fastcdr::CdrVersion::XCDRv1
-                             ? eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR
-                             : eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
+                             ? data.enc_xcdrv1
+                             : data.enc_xcdrv2);
     cdr << MemberId(3) << data.value1;
     cdr << MemberId(16) << data.value2;
     cdr.end_serialize_type(current_status);
@@ -230,14 +248,14 @@ void serialize(
 template<>
 void deserialize(
         Cdr& cdr,
-        InnerFinalStructure& data)
+        MuInnerStructure& data)
 {
     cdr.deserialize_type(cdr.get_cdr_version() == eprosima::fastcdr::CdrVersion::XCDRv1
-                         ? eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR
-                         : eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2,
+                         ? data.enc_xcdrv1
+                         : data.enc_xcdrv2,
             [&data](Cdr& cdr_inner, const MemberId& mid) -> bool
             {
-                bool ret_value = true;
+                bool ret_value {true};
                 switch (mid.id)
                 {
                     case 0:
@@ -1022,7 +1040,8 @@ TEST_P(XCdrMutableTest, inner_final_structure)
 
     //{ Encode
     uint32_t value1 {ival};
-    InnerFinalStructure value2 {ival};
+    MuInnerStructure value2 {eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2, ival};
     cdr.set_encoding_flag(encoding);
     cdr.serialize_encapsulation();
     Cdr::state enc_state(cdr);
@@ -1041,14 +1060,153 @@ TEST_P(XCdrMutableTest, inner_final_structure)
 
     //{ Decoding
     uint32_t dvalue1 {0};
-    InnerFinalStructure dvalue2;
+    MuInnerStructure dvalue2 {eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                              eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2, ival};
     cdr.reset();
     cdr.read_encapsulation();
     ASSERT_EQ(cdr.get_encoding_flag(), encoding);
     ASSERT_EQ(cdr.endianness(), endianness);
     cdr.deserialize_type(encoding, [&](Cdr& cdr_inner, const MemberId& mid)->bool
             {
-                bool ret_value = true;
+                bool ret_value {true};
+
+                switch (mid.id)
+                {
+                    case 1:
+                        cdr_inner >> dvalue1;
+                        break;
+                    case 2:
+                        cdr_inner >> dvalue2;
+                        break;
+                    default:
+                        ret_value = false;
+                        break;
+                }
+
+                return ret_value;
+            });
+    ASSERT_EQ(value1, dvalue1);
+    ASSERT_EQ(value2, dvalue2);
+    Cdr::state dec_state_end(cdr);
+    ASSERT_EQ(enc_state_end, dec_state_end);
+    //}
+}
+
+/*!
+ * @test Test an inner appendable structure inside a mutable structure.
+ * @code{.idl}
+ * @appendable
+ * struct InnerAppendableStructure
+ * {
+ *     @id(3)
+ *     unsigned long value1;
+ *     @id(16) @optional
+ *     unsigned long value2;
+ * };
+ *
+ * @mutable
+ * struct MutableWithInnerAppendableStruct
+ * {
+ *     @id(1)
+ *     unsigned long value1;
+ *     @id(2)
+ *     InnerAppendableStructure value2;
+ * };
+ * @endcode
+ */
+TEST_P(XCdrMutableTest, inner_appendable_structure)
+{
+    constexpr uint8_t ival {0xCD};
+
+    //{ Defining expected XCDR streams
+    XCdrStreamValues expected_streams;
+    expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x02, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x04, // ShortMemberHeader
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00, 0x02, 0x00, 0x08, // ShortMemberHeader
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00, 0x10, 0x00, 0x00, // ShortMemberHeader (optional)
+        0x3F, 0x02, 0x00, 0x00, // Sentinel
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x03, 0x00, 0x00, // Encapsulation
+        0x01, 0x00, 0x04, 0x00, // ShortMemberHeader
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x02, 0x00, 0x08, 0x00, // ShortMemberHeader
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x10, 0x00, 0x00, 0x00, // ShortMemberHeader
+        0x02, 0x3F, 0x00, 0x00, // Sentinel
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x15, // DHEADER
+        0x20, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
+        0x00, 0x00, 0x00, ival, // ULong
+        0x50, 0x00, 0x00, 0x02, // EMHEADER1(M) with NEXTINT
+        0x00, 0x00, 0x00, 0x05, // NEXTINT + DHEADER
+        0x00, 0x00, 0x00, ival, // ULong
+        0x00,                   // Optional not present
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x15, 0x00, 0x00, 0x00, // DHEADER
+        0x01, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x02, 0x00, 0x00, 0x50, // EMHEADER1(M) with NEXTINT
+        0x05, 0x00, 0x00, 0x00, // NEXTINT + DHEADER
+        ival, 0x00, 0x00, 0x00, // ULong
+        0x00,                   // Optional not present
+    };
+    //}
+
+    EncodingAlgorithmFlag encoding = std::get<0>(GetParam());
+    Cdr::Endianness endianness = std::get<1>(GetParam());
+
+    //{ Prepare buffer
+    uint8_t tested_stream = 0 + encoding + endianness;
+    auto buffer =
+            std::unique_ptr<char, void (*)(
+        void*)>{reinterpret_cast<char*>(calloc(expected_streams[tested_stream].size(), sizeof(char))), free};
+    FastBuffer fast_buffer(buffer.get(), expected_streams[tested_stream].size());
+    Cdr cdr(fast_buffer, endianness, get_version_from_algorithm(encoding));
+    //}
+
+    //{ Encode
+    uint32_t value1 {ival};
+    MuInnerStructure value2 {eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2, ival};
+    cdr.set_encoding_flag(encoding);
+    cdr.serialize_encapsulation();
+    Cdr::state enc_state(cdr);
+    cdr.begin_serialize_type(enc_state, encoding);
+    cdr << MemberId(1) << value1;
+    cdr << MemberId(2) << value2;
+    cdr.end_serialize_type(enc_state);
+    Cdr::state enc_state_end(cdr);
+    //}
+
+    //{ Test encoded content
+    ASSERT_EQ(cdr.get_serialized_data_length(), expected_streams[tested_stream].size());
+    ASSERT_EQ(0, memcmp(buffer.get(), expected_streams[tested_stream].data(),
+            expected_streams[tested_stream].size()));
+    //}
+
+    //{ Decoding
+    uint32_t dvalue1 {0};
+    MuInnerStructure dvalue2 {eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                              eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2, ival};
+    cdr.reset();
+    cdr.read_encapsulation();
+    ASSERT_EQ(cdr.get_encoding_flag(), encoding);
+    ASSERT_EQ(cdr.endianness(), endianness);
+    cdr.deserialize_type(encoding, [&](Cdr& cdr_inner, const MemberId& mid)->bool
+            {
+                bool ret_value {true};
 
                 switch (mid.id)
                 {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR fixes encoding/decoding of a structure with an inner structure with different extensibility.
```omg-idl
@appendable
struct InnerAppendableStructure
{
    @id(3)
    unsigned long value1;
    @id(16) @optional
    unsigned long value2;
 };

@mutable
struct MutableWithInnerAppendableStruct
{
   @id(1)
   unsigned long value1;
   @id(2)
   InnerAppendableStructure value2;
};
```

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.2.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: CI pass and failing tests are unrelated with the changes.

