### PR TITLE
[22041] Support setting and encoding options with least significant bits set with possible padding

### DIFF
--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -3548,6 +3548,12 @@ private:
     //! Specifies if a DHEADER was serialized. Used to optimize XCDRv2 member headers.
     serialized_member_size_ {NO_SERIALIZED_MEMBER_SIZE};
 
+    //! Stores the initial state.
+    state initial_state_;
+
+    //! Whether the encapsulation was serialized.
+    bool encapsulation_serialized_ {false};
+
 
     uint32_t get_long_lc(
             SerializedMemberSizeForNextInt serialized_member_size);

--- a/test/xcdr/basic_types.cpp
+++ b/test/xcdr/basic_types.cpp
@@ -289,6 +289,7 @@ void serialize(
         cdr << MemberId(1) << value;
     }
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -373,6 +374,7 @@ void align_serialize(
         cdr << MemberId(0) << align_value << MemberId(1) << value;
     }
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -478,6 +480,7 @@ void longdouble_align_serialize(
         cdr << MemberId(0) << align_value << MemberId(1) << value;
     }
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -561,12 +564,12 @@ TEST_P(XCdrBasicTypesTest, short)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         ival, fval              // Short
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         fval, ival              // Short
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
@@ -587,36 +590,36 @@ TEST_P(XCdrBasicTypesTest, short)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         ival, fval              // Short
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         fval, ival              // Short
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x02, // DHEADER
         ival, fval              // Short
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x02, 0x00, 0x00, 0x00, // DHEADER
         fval, ival              // Short
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         0x10, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         ival, fval              // Short
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fval, ival              // Short
@@ -650,12 +653,12 @@ TEST_P(XCdrBasicTypesTest, ushort)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         ival, fval              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         fval, ival              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
@@ -676,36 +679,36 @@ TEST_P(XCdrBasicTypesTest, ushort)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         ival, fval              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         fval, ival              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x02, // DHEADER
         ival, fval              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x02, 0x00, 0x00, 0x00, // DHEADER
         fval, ival              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         0x10, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         ival, fval              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fval, ival              // UShort
@@ -1403,6 +1406,7 @@ TEST_P(XCdrBasicTypesTest, longdouble)
         cdr.begin_serialize_type(enc_state, encoding);
         cdr.serialize_member(MemberId(1), value);
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 
@@ -1462,6 +1466,7 @@ TEST_P(XCdrBasicTypesTest, longdouble)
         cdr.begin_serialize_type(enc_state, encoding);
         cdr << MemberId(1) << value;
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 
@@ -1521,12 +1526,12 @@ TEST_P(XCdrBasicTypesTest, boolean)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
@@ -1547,36 +1552,36 @@ TEST_P(XCdrBasicTypesTest, boolean)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x03, // Encapsulation
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x03, // Encapsulation
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x01, // DHEADER
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x03, // Encapsulation
         0x01, 0x00, 0x00, 0x00, // DHEADER
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x05, // DHEADER
         0x00, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         b_value                 // Boolean
@@ -1608,12 +1613,12 @@ TEST_P(XCdrBasicTypesTest, octet)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
@@ -1634,36 +1639,36 @@ TEST_P(XCdrBasicTypesTest, octet)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x03, // Encapsulation
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x03, // Encapsulation
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x01, // DHEADER
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x03, // Encapsulation
         0x01, 0x00, 0x00, 0x00, // DHEADER
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x05, // DHEADER
         0x00, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         octet_value             // Octet
@@ -1696,12 +1701,12 @@ TEST_P(XCdrBasicTypesTest, char)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
@@ -1722,36 +1727,36 @@ TEST_P(XCdrBasicTypesTest, char)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x03, // Encapsulation
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x03, // Encapsulation
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x01, // DHEADER
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x03, // Encapsulation
         0x01, 0x00, 0x00, 0x00, // DHEADER
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x05, // DHEADER
         0x00, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         valu                    // Char
@@ -1785,12 +1790,12 @@ TEST_P(XCdrBasicTypesTest, wchar)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         ival, fval              // Wchar
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         fval, ival              // Wchar
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
@@ -1811,36 +1816,36 @@ TEST_P(XCdrBasicTypesTest, wchar)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         ival, fval              // Wchar
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         fval, ival              // Wchar
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x02, // DHEADER
         ival, fval              // Wchar
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x02, 0x00, 0x00, 0x00, // DHEADER
         fval, ival              // Wchar
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         0x10, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         ival, fval              // Wchar
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fval, ival              // Wchar
@@ -1874,13 +1879,13 @@ TEST_P(XCdrBasicTypesTest, string)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x03, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x01, // Encapsulation
         0x03, 0x00, 0x00, 0x00, // String length
         valA, valB, 0x00        // String
     };
@@ -1904,33 +1909,33 @@ TEST_P(XCdrBasicTypesTest, string)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x03, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x01, // Encapsulation
         0x03, 0x00, 0x00, 0x00, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x07, // DHEADER
         0x00, 0x00, 0x00, 0x03, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x01, // Encapsulation
         0x07, 0x00, 0x00, 0x00, // DHEADER
         0x03, 0x00, 0x00, 0x00, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x0B, // DHEADER
         0x50, 0x00, 0x00, 0x01, // EMHEADER1(M) with NEXTINT
         0x00, 0x00, 0x00, 0x03, // String length
@@ -1938,7 +1943,7 @@ TEST_P(XCdrBasicTypesTest, string)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x01, // Encapsulation
         0x0B, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x50, // EMHEADER1(M) with NEXTINT
         0x03, 0x00, 0x00, 0x00, // String length
@@ -2080,13 +2085,13 @@ TEST_P(XCdrBasicTypesTest, fixed_string)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x03, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x01, // Encapsulation
         0x03, 0x00, 0x00, 0x00, // String length
         valA, valB, 0x00        // String
     };
@@ -2110,33 +2115,33 @@ TEST_P(XCdrBasicTypesTest, fixed_string)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x03, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x01, // Encapsulation
         0x03, 0x00, 0x00, 0x00, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x07, // DHEADER
         0x00, 0x00, 0x00, 0x03, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x01, // Encapsulation
         0x07, 0x00, 0x00, 0x00, // DHEADER
         0x03, 0x00, 0x00, 0x00, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x0B, // DHEADER
         0x50, 0x00, 0x00, 0x01, // EMHEADER1(M) with NEXTINT
         0x00, 0x00, 0x00, 0x03, // String length
@@ -2144,7 +2149,7 @@ TEST_P(XCdrBasicTypesTest, fixed_string)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x01, // Encapsulation
         0x0B, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x50, // EMHEADER1(M) with NEXTINT
         0x03, 0x00, 0x00, 0x00, // String length
@@ -2275,12 +2280,12 @@ TEST_P(XCdrBasicTypesTest, enum16)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         0x00, 0x01              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         0x01, 0x00              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
@@ -2301,36 +2306,36 @@ TEST_P(XCdrBasicTypesTest, enum16)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         0x00, 0x01              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         0x01, 0x00              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x02, // DHEADER
         0x00, 0x01              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x02, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         0x10, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         0x00, 0x01              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         0x01, 0x00              // UShort
@@ -2369,19 +2374,19 @@ TEST_P(XCdrBasicTypesTest, enum8)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
-        0x01             // Octet
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
+        0x01                    // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
-        0x01             // Octet
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
+        0x01                    // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
         0x00, 0x02, 0x00, 0x00, // Encapsulation
         0x00, 0x01, 0x00, 0x01, // ShortMemberHeader
-        0x01,            // Octet
+        0x01,                   // Octet
         0x00, 0x00, 0x00,       // Alignment
         0x3F, 0x02, 0x00, 0x00  // Sentinel
     };
@@ -2389,45 +2394,45 @@ TEST_P(XCdrBasicTypesTest, enum8)
     {
         0x00, 0x03, 0x00, 0x00, // Encapsulation
         0x01, 0x00, 0x01, 0x00, // ShortMemberHeader
-        0x01,            // Octet
+        0x01,                   // Octet
         0x00, 0x00, 0x00,       // Alignment
         0x02, 0x3F, 0x00, 0x00  // Sentinel
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
-        0x01             // Octet
+        0x00, 0x06, 0x00, 0x03, // Encapsulation
+        0x01                    // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
-        0x01             // Octet
+        0x00, 0x07, 0x00, 0x03, // Encapsulation
+        0x01                    // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x01, // DHEADER
-        0x01             // Octet
+        0x01                    // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x03, // Encapsulation
         0x01, 0x00, 0x00, 0x00, // DHEADER
-        0x01             // Octet
+        0x01                    // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x05, // DHEADER
         0x00, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
-        0x01             // Octet
+        0x01                    // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
-        0x01             // Octet
+        0x01                    // Octet
     };
     //}
 
@@ -2658,7 +2663,7 @@ TEST_P(XCdrBasicTypesTest, array_struct)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x2E, // DHEADER
         0x50, 0x00, 0x00, 0x01, // EMHEADER1(M) with NEXTINT
         0x00, 0x00, 0x00, 0x26, // DHEADER + NEXTINT
@@ -2678,7 +2683,7 @@ TEST_P(XCdrBasicTypesTest, array_struct)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x2E, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x50, // EMHEADER1(M) with NEXTINT
         0x26, 0x00, 0x00, 0x00, // DHEADER + NEXTINT
@@ -3006,7 +3011,7 @@ TEST_P(XCdrBasicTypesTest, multi_array_struct)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x56, // DHEADER
         0x50, 0x00, 0x00, 0x01, // EMHEADER1(M) with NEXTINT
         0x00, 0x00, 0x00, 0x4E, // DHEADER + NEXTINT
@@ -3040,7 +3045,7 @@ TEST_P(XCdrBasicTypesTest, multi_array_struct)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x56, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x50, // EMHEADER1(M) with NEXTINT
         0x4E, 0x00, 0x00, 0x00, // DHEADER + NEXTINT
@@ -3319,7 +3324,7 @@ TEST_P(XCdrBasicTypesTest, sequence_struct)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x32, // DHEADER
         0x50, 0x00, 0x00, 0x01, // EMHEADER1(M) with NEXTINT
         0x00, 0x00, 0x00, 0x2A, // DHEADER + NEXTINT
@@ -3340,7 +3345,7 @@ TEST_P(XCdrBasicTypesTest, sequence_struct)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x32, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x50, // EMHEADER1(M) with NEXTINT
         0x2A, 0x00, 0x00, 0x00, // DHEADER + NEXTINT
@@ -3734,7 +3739,7 @@ TEST_P(XCdrBasicTypesTest, recursive_sequence_struct)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x6A, // DHEADER
         0x50, 0x00, 0x00, 0x01, // EMHEADER1(M) with NEXTINT
         0x00, 0x00, 0x00, 0x62, // DHEADER + NEXTINT
@@ -3773,7 +3778,7 @@ TEST_P(XCdrBasicTypesTest, recursive_sequence_struct)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x6A, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x50, // EMHEADER1(M) with NEXTINT
         0x62, 0x00, 0x00, 0x00, // DHEADER + NEXTINT
@@ -4126,7 +4131,7 @@ TEST_P(XCdrBasicTypesTest, map_struct)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x36, // DHEADER
         0x50, 0x00, 0x00, 0x01, // EMHEADER1(M) with NEXTINT
         0x00, 0x00, 0x00, 0x2e, // DHEADER + NEXTINT
@@ -4149,7 +4154,7 @@ TEST_P(XCdrBasicTypesTest, map_struct)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x36, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x50, // EMHEADER1(M) with NEXTINT
         0x2e, 0x00, 0x00, 0x00, // DHEADER + NEXTINT
@@ -4203,12 +4208,12 @@ TEST_P(XCdrBasicTypesTest, bitset_8)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         ival                    // Bitset
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         ival                    // Bitset
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
@@ -4229,36 +4234,36 @@ TEST_P(XCdrBasicTypesTest, bitset_8)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x03, // Encapsulation
         ival,                   // Bitset
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x03, // Encapsulation
         ival                    // Bitset
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x01, // DHEADER
         ival,                   // Bitset
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x03, // Encapsulation
         0x01, 0x00, 0x00, 0x00, // DHEADER
         ival                    // Bitset
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x05, // DHEADER
         0x00, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         ival,                   // Bitset
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         ival                    // Bitset
@@ -4297,12 +4302,12 @@ TEST_P(XCdrBasicTypesTest, bitset_16)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         ival, fval              // Bitset
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         fval, ival              // Bitset
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
@@ -4323,36 +4328,36 @@ TEST_P(XCdrBasicTypesTest, bitset_16)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         ival, fval              // Bitset
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         fval, ival              // Bitset
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x02, // DHEADER
         ival, fval              // Bitset
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x02, 0x00, 0x00, 0x00, // DHEADER
         fval, ival              // Bitset
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         0x10, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         ival, fval              // Bitset
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fval, ival              // Bitset
@@ -4648,7 +4653,7 @@ TEST_P(XCdrBasicTypesTest, short_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -4658,7 +4663,7 @@ TEST_P(XCdrBasicTypesTest, short_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -4759,7 +4764,7 @@ TEST_P(XCdrBasicTypesTest, short_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x10, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, fava,
@@ -4769,7 +4774,7 @@ TEST_P(XCdrBasicTypesTest, short_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fava, iava,
@@ -4810,13 +4815,13 @@ TEST_P(XCdrBasicTypesTest, short_align_4)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         iava, iava, iava, fava,
         ival, fval              // Short
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         fava, iava, iava, iava,
         fval, ival              // Short
     };
@@ -4842,33 +4847,33 @@ TEST_P(XCdrBasicTypesTest, short_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         iava, iava, iava, fava,
         ival, fval              // Short
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         fava, iava, iava, iava,
         fval, ival              // Short
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         iava, iava, iava, fava,
         ival, fval              // Short
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         fava, iava, iava, iava,
         fval, ival              // Short
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, iava, iava, fava,
@@ -4877,7 +4882,7 @@ TEST_P(XCdrBasicTypesTest, short_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         fava, iava, iava, iava,
@@ -4981,7 +4986,7 @@ TEST_P(XCdrBasicTypesTest, ushort_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -4991,7 +4996,7 @@ TEST_P(XCdrBasicTypesTest, ushort_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -5092,7 +5097,7 @@ TEST_P(XCdrBasicTypesTest, ushort_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x10, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, fava,
@@ -5102,7 +5107,7 @@ TEST_P(XCdrBasicTypesTest, ushort_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fava, iava,
@@ -5143,13 +5148,13 @@ TEST_P(XCdrBasicTypesTest, ushort_align_4)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         iava, iava, iava, fava,
         ival, fval              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         fava, iava, iava, iava,
         fval, ival              // UShort
     };
@@ -5175,33 +5180,33 @@ TEST_P(XCdrBasicTypesTest, ushort_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         iava, iava, iava, fava,
         ival, fval              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         fava, iava, iava, iava,
         fval, ival              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         iava, iava, iava, fava,
         ival, fval              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         fava, iava, iava, iava,
         fval, ival              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, iava, iava, fava,
@@ -5210,7 +5215,7 @@ TEST_P(XCdrBasicTypesTest, ushort_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         fava, iava, iava, iava,
@@ -7758,13 +7763,13 @@ TEST_P(XCdrBasicTypesTest, boolean_align_1)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         align_value,
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         align_value,
         b_value                 // Boolean
     };
@@ -7792,33 +7797,33 @@ TEST_P(XCdrBasicTypesTest, boolean_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         align_value,
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         align_value,
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x02, // DHEADER
         align_value,
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x02, 0x00, 0x00, 0x00, // DHEADER
         align_value,
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -7828,7 +7833,7 @@ TEST_P(XCdrBasicTypesTest, boolean_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -7868,13 +7873,13 @@ TEST_P(XCdrBasicTypesTest, boolean_align_2)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x01, // Encapsulation
         iava, fava,
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x01, // Encapsulation
         fava, iava,
         b_value                 // Boolean
     };
@@ -7902,33 +7907,33 @@ TEST_P(XCdrBasicTypesTest, boolean_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x01, // Encapsulation
         iava, fava,
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x01, // Encapsulation
         fava, iava,
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x03, // DHEADER
         iava, fava,
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x01, // Encapsulation
         0x03, 0x00, 0x00, 0x00, // DHEADER
         fava, iava,
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x10, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, fava,
@@ -7938,7 +7943,7 @@ TEST_P(XCdrBasicTypesTest, boolean_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fava, iava,
@@ -7978,13 +7983,13 @@ TEST_P(XCdrBasicTypesTest, boolean_align_4)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         iava, iava, iava, fava,
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         fava, iava, iava, iava,
         b_value                 // Boolean
     };
@@ -8010,33 +8015,33 @@ TEST_P(XCdrBasicTypesTest, boolean_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x03, // Encapsulation
         iava, iava, iava, fava,
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x03, // Encapsulation
         fava, iava, iava, iava,
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x05, // DHEADER
         iava, iava, iava, fava,
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         fava, iava, iava, iava,
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, iava, iava, fava,
@@ -8045,7 +8050,7 @@ TEST_P(XCdrBasicTypesTest, boolean_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         fava, iava, iava, iava,
@@ -8081,13 +8086,13 @@ TEST_P(XCdrBasicTypesTest, octet_align_1)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         align_value,
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         align_value,
         octet_value             // Octet
     };
@@ -8115,33 +8120,33 @@ TEST_P(XCdrBasicTypesTest, octet_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         align_value,
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         align_value,
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x02, // DHEADER
         align_value,
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x02, 0x00, 0x00, 0x00, // DHEADER
         align_value,
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -8151,7 +8156,7 @@ TEST_P(XCdrBasicTypesTest, octet_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -8190,13 +8195,13 @@ TEST_P(XCdrBasicTypesTest, octet_align_2)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x01, // Encapsulation
         iava, fava,
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x01, // Encapsulation
         fava, iava,
         octet_value             // Octet
     };
@@ -8224,33 +8229,33 @@ TEST_P(XCdrBasicTypesTest, octet_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x01, // Encapsulation
         iava, fava,
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x01, // Encapsulation
         fava, iava,
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x03, // DHEADER
         iava, fava,
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x01, // Encapsulation
         0x03, 0x00, 0x00, 0x00, // DHEADER
         fava, iava,
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x10, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, fava,
@@ -8260,7 +8265,7 @@ TEST_P(XCdrBasicTypesTest, octet_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fava, iava,
@@ -8299,13 +8304,13 @@ TEST_P(XCdrBasicTypesTest, octet_align_4)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         iava, iava, iava, fava,
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         fava, iava, iava, iava,
         octet_value             // Octet
     };
@@ -8331,33 +8336,33 @@ TEST_P(XCdrBasicTypesTest, octet_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x03, // Encapsulation
         iava, iava, iava, fava,
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x03, // Encapsulation
         fava, iava, iava, iava,
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x05, // DHEADER
         iava, iava, iava, fava,
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         fava, iava, iava, iava,
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, iava, iava, fava,
@@ -8366,7 +8371,7 @@ TEST_P(XCdrBasicTypesTest, octet_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         fava, iava, iava, iava,
@@ -8403,13 +8408,13 @@ TEST_P(XCdrBasicTypesTest, char_align_1)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         align_value,
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         align_value,
         valu                    // Char
     };
@@ -8437,33 +8442,33 @@ TEST_P(XCdrBasicTypesTest, char_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         align_value,
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         align_value,
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x02, // DHEADER
         align_value,
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x02, 0x00, 0x00, 0x00, // DHEADER
         align_value,
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -8473,7 +8478,7 @@ TEST_P(XCdrBasicTypesTest, char_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -8513,13 +8518,13 @@ TEST_P(XCdrBasicTypesTest, char_align_2)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x01, // Encapsulation
         iava, fava,
         valu                     // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x01, // Encapsulation
         fava, iava,
         valu                    // Char
     };
@@ -8547,33 +8552,33 @@ TEST_P(XCdrBasicTypesTest, char_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x01, // Encapsulation
         iava, fava,
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x01, // Encapsulation
         fava, iava,
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x03, // DHEADER
         iava, fava,
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x01, // Encapsulation
         0x03, 0x00, 0x00, 0x00, // DHEADER
         fava, iava,
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x10, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, fava,
@@ -8583,7 +8588,7 @@ TEST_P(XCdrBasicTypesTest, char_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fava, iava,
@@ -8623,13 +8628,13 @@ TEST_P(XCdrBasicTypesTest, char_align_4)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         iava, iava, iava, fava,
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         fava, iava, iava, iava,
         valu                    // Char
     };
@@ -8655,33 +8660,33 @@ TEST_P(XCdrBasicTypesTest, char_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x03, // Encapsulation
         iava, iava, iava, fava,
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x03, // Encapsulation
         fava, iava, iava, iava,
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x05, // DHEADER
         iava, iava, iava, fava,
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         fava, iava, iava, iava,
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, iava, iava, fava,
@@ -8690,7 +8695,7 @@ TEST_P(XCdrBasicTypesTest, char_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         fava, iava, iava, iava,
@@ -8794,7 +8799,7 @@ TEST_P(XCdrBasicTypesTest, wchar_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -8804,7 +8809,7 @@ TEST_P(XCdrBasicTypesTest, wchar_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -8905,7 +8910,7 @@ TEST_P(XCdrBasicTypesTest, wchar_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x10, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, fava,
@@ -8915,7 +8920,7 @@ TEST_P(XCdrBasicTypesTest, wchar_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fava, iava,
@@ -8956,13 +8961,13 @@ TEST_P(XCdrBasicTypesTest, wchar_align_4)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         iava, iava, iava, fava,
         ival, fval              // WChar
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         fava, iava, iava, iava,
         fval, ival              // WChar
     };
@@ -8988,33 +8993,33 @@ TEST_P(XCdrBasicTypesTest, wchar_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         iava, iava, iava, fava,
         ival, fval              // WChar
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         fava, iava, iava, iava,
         fval, ival              // WChar
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         iava, iava, iava, fava,
         ival, fval              // WChar
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         fava, iava, iava, iava,
         fval, ival              // WChar
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, iava, iava, fava,
@@ -9023,7 +9028,7 @@ TEST_P(XCdrBasicTypesTest, wchar_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         fava, iava, iava, iava,
@@ -9061,7 +9066,7 @@ TEST_P(XCdrBasicTypesTest, string_align_1)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x01, // Encapsulation
         align_value,
         0x00, 0x00, 0x00,       // Alignment
         0x00, 0x00, 0x00, 0x03, // String length
@@ -9069,7 +9074,7 @@ TEST_P(XCdrBasicTypesTest, string_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x01, // Encapsulation
         align_value,
         0x00, 0x00, 0x00,       // Alignment
         0x03, 0x00, 0x00, 0x00, // String length
@@ -9101,7 +9106,7 @@ TEST_P(XCdrBasicTypesTest, string_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x01, // Encapsulation
         align_value,
         0x00, 0x00, 0x00,       // Alignment
         0x00, 0x00, 0x00, 0x03, // String length
@@ -9109,7 +9114,7 @@ TEST_P(XCdrBasicTypesTest, string_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x01, // Encapsulation
         align_value,
         0x00, 0x00, 0x00,       // Alignment
         0x03, 0x00, 0x00, 0x00, // String length
@@ -9117,7 +9122,7 @@ TEST_P(XCdrBasicTypesTest, string_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x0B, // DHEADER
         align_value,
         0x00, 0x00, 0x00,       // Alignment
@@ -9126,7 +9131,7 @@ TEST_P(XCdrBasicTypesTest, string_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x01, // Encapsulation
         0x0B, 0x00, 0x00, 0x00, // DHEADER
         align_value,
         0x00, 0x00, 0x00,       // Alignment
@@ -9135,7 +9140,7 @@ TEST_P(XCdrBasicTypesTest, string_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x13, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -9146,7 +9151,7 @@ TEST_P(XCdrBasicTypesTest, string_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x01, // Encapsulation
         0x13, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -9188,7 +9193,7 @@ TEST_P(XCdrBasicTypesTest, string_align_2)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x01, // Encapsulation
         iava, fava,
         0x00, 0x00,             // Alignment
         0x00, 0x00, 0x00, 0x03, // String length
@@ -9196,7 +9201,7 @@ TEST_P(XCdrBasicTypesTest, string_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x01, // Encapsulation
         fava, iava,
         0x00, 0x00,             // Alignment
         0x03, 0x00, 0x00, 0x00, // String length
@@ -9228,7 +9233,7 @@ TEST_P(XCdrBasicTypesTest, string_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x01, // Encapsulation
         iava, fava,
         0x00, 0x00,             // Alignment
         0x00, 0x00, 0x00, 0x03, // String length
@@ -9236,7 +9241,7 @@ TEST_P(XCdrBasicTypesTest, string_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x01, // Encapsulation
         fava, iava,
         0x00, 0x00,             // Alignment
         0x03, 0x00, 0x00, 0x00, // String length
@@ -9244,7 +9249,7 @@ TEST_P(XCdrBasicTypesTest, string_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x0B, // DHEADER
         iava, fava,
         0x00, 0x00,             // Alignment
@@ -9253,7 +9258,7 @@ TEST_P(XCdrBasicTypesTest, string_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x01, // Encapsulation
         0x0B, 0x00, 0x00, 0x00, // DHEADER
         fava, iava,
         0x00, 0x00,             // Alignment
@@ -9262,7 +9267,7 @@ TEST_P(XCdrBasicTypesTest, string_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x13, // DHEADER
         0x10, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, fava,
@@ -9273,7 +9278,7 @@ TEST_P(XCdrBasicTypesTest, string_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x01, // Encapsulation
         0x13, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fava, iava,
@@ -9315,14 +9320,14 @@ TEST_P(XCdrBasicTypesTest, string_align_4)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x01, // Encapsulation
         iava, iava, iava, fava,
         0x00, 0x00, 0x00, 0x03, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x01, // Encapsulation
         fava, iava, iava, iava,
         0x03, 0x00, 0x00, 0x00, // String length
         valA, valB, 0x00        // String
@@ -9351,21 +9356,21 @@ TEST_P(XCdrBasicTypesTest, string_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x01, // Encapsulation
         iava, iava, iava, fava,
         0x00, 0x00, 0x00, 0x03, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x01, // Encapsulation
         fava, iava, iava, iava,
         0x03, 0x00, 0x00, 0x00, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x0B, // DHEADER
         iava, iava, iava, fava,
         0x00, 0x00, 0x00, 0x03, // String length
@@ -9373,7 +9378,7 @@ TEST_P(XCdrBasicTypesTest, string_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x01, // Encapsulation
         0x0B, 0x00, 0x00, 0x00, // DHEADER
         fava, iava, iava, iava,
         0x03, 0x00, 0x00, 0x00, // String length
@@ -9381,7 +9386,7 @@ TEST_P(XCdrBasicTypesTest, string_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x13, // DHEADER
         0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, iava, iava, fava,
@@ -9391,7 +9396,7 @@ TEST_P(XCdrBasicTypesTest, string_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x01, // Encapsulation
         0x13, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         fava, iava, iava, iava,
@@ -10238,7 +10243,7 @@ TEST_P(XCdrBasicTypesTest, enum16_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -10248,7 +10253,7 @@ TEST_P(XCdrBasicTypesTest, enum16_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -10353,7 +10358,7 @@ TEST_P(XCdrBasicTypesTest, enum16_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x10, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, fava,
@@ -10363,7 +10368,7 @@ TEST_P(XCdrBasicTypesTest, enum16_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fava, iava,
@@ -10408,13 +10413,13 @@ TEST_P(XCdrBasicTypesTest, enum16_align_4)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         iava, iava, iava, fava,
         0x00, 0x01              // Enum16
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         fava, iava, iava, iava,
         0x01, 0x00              // Enum16
     };
@@ -10440,33 +10445,33 @@ TEST_P(XCdrBasicTypesTest, enum16_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         iava, iava, iava, fava,
         0x00, 0x01              // Enum16
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         fava, iava, iava, iava,
         0x01, 0x00              // Enum16
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         iava, iava, iava, fava,
         0x00, 0x01              // Enum16
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         fava, iava, iava, iava,
         0x01, 0x00              // Enum16
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, iava, iava, fava,
@@ -10475,7 +10480,7 @@ TEST_P(XCdrBasicTypesTest, enum16_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         fava, iava, iava, iava,
@@ -10517,13 +10522,13 @@ TEST_P(XCdrBasicTypesTest, enum8_align_1)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         align_value,
         enum_value              // Enum8
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         align_value,
         enum_value              // Enum8
     };
@@ -10551,33 +10556,33 @@ TEST_P(XCdrBasicTypesTest, enum8_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         align_value,
         enum_value              // Enum8
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         align_value,
         enum_value              // Enum8
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x02, // DHEADER
         align_value,
         enum_value              // Enum8
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x02, 0x00, 0x00, 0x00, // DHEADER
         align_value,
         enum_value              // Enum8
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -10587,7 +10592,7 @@ TEST_P(XCdrBasicTypesTest, enum8_align_1)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -10632,13 +10637,13 @@ TEST_P(XCdrBasicTypesTest, enum8_align_2)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x01, // Encapsulation
         iava, fava,
         enum_value              // Enum8
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x01, // Encapsulation
         fava, iava,
         enum_value              // Enum8
     };
@@ -10666,33 +10671,33 @@ TEST_P(XCdrBasicTypesTest, enum8_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x01, // Encapsulation
         iava, fava,
         enum_value              // Enum8
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x01, // Encapsulation
         fava, iava,
         enum_value              // Enum8
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x03, // DHEADER
         iava, fava,
         enum_value              // Enum8
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x01, // Encapsulation
         0x03, 0x00, 0x00, 0x00, // DHEADER
         fava, iava,
         enum_value              // Enum8
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x10, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, fava,
@@ -10702,7 +10707,7 @@ TEST_P(XCdrBasicTypesTest, enum8_align_2)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fava, iava,
@@ -10747,13 +10752,13 @@ TEST_P(XCdrBasicTypesTest, enum8_align_4)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         iava, iava, iava, fava,
         enum_value              // Enum8
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         fava, iava, iava, iava,
         enum_value              // Enum8
     };
@@ -10779,33 +10784,33 @@ TEST_P(XCdrBasicTypesTest, enum8_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x03, // Encapsulation
         iava, iava, iava, fava,
         enum_value              // Enum8
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x03, // Encapsulation
         fava, iava, iava, iava,
         enum_value              // Enum8
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x05, // DHEADER
         iava, iava, iava, fava,
         enum_value              // Enum8
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         fava, iava, iava, iava,
         enum_value              // Enum8
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, iava, iava, fava,
@@ -10814,7 +10819,7 @@ TEST_P(XCdrBasicTypesTest, enum8_align_4)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         fava, iava, iava, iava,
@@ -10857,7 +10862,7 @@ TEST_P(XCdrBasicTypesTest, struct_with_strings)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x03, // String length
         valA, valB, 0x00,       // String
         0x00,                   // Alignment
@@ -10869,7 +10874,7 @@ TEST_P(XCdrBasicTypesTest, struct_with_strings)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x01, // Encapsulation
         0x03, 0x00, 0x00, 0x00, // String length
         valA, valB, 0x00,       // String
         0x00,                   // Alignment
@@ -10915,7 +10920,7 @@ TEST_P(XCdrBasicTypesTest, struct_with_strings)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x03, // String length
         valA, valB, 0x00,       // String
         0x00,                   // Alignment
@@ -10927,7 +10932,7 @@ TEST_P(XCdrBasicTypesTest, struct_with_strings)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x01, // Encapsulation
         0x03, 0x00, 0x00, 0x00, // String length
         valA, valB, 0x00,       // String
         0x00,                   // Alignment
@@ -10939,7 +10944,7 @@ TEST_P(XCdrBasicTypesTest, struct_with_strings)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x17, // DHEADER
         0x00, 0x00, 0x00, 0x03, // String length
         valA, valB, 0x00,       // String
@@ -10952,7 +10957,7 @@ TEST_P(XCdrBasicTypesTest, struct_with_strings)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x01, // Encapsulation
         0x17, 0x00, 0x00, 0x00, // DHEADER
         0x03, 0x00, 0x00, 0x00, // String length
         valA, valB, 0x00,       // String
@@ -10965,7 +10970,7 @@ TEST_P(XCdrBasicTypesTest, struct_with_strings)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x23, // DHEADER
         0x50, 0x00, 0x00, 0x01, // EMHEADER1(M) with NEXTINT
         0x00, 0x00, 0x00, 0x03, // String length
@@ -10981,7 +10986,7 @@ TEST_P(XCdrBasicTypesTest, struct_with_strings)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x01, // Encapsulation
         0x23, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x50, // EMHEADER1(M) with NEXTINT
         0x03, 0x00, 0x00, 0x00, // String length
@@ -11030,6 +11035,7 @@ TEST_P(XCdrBasicTypesTest, struct_with_strings)
         cdr.serialize_member(MemberId(2), var_field2);
         cdr.serialize_member(MemberId(3), var_field3);
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 
@@ -11119,6 +11125,7 @@ TEST_P(XCdrBasicTypesTest, struct_with_strings)
         cdr << MemberId(2) << var_field2;
         cdr << MemberId(3) << var_field3;
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 
@@ -11324,7 +11331,7 @@ TEST_P(XCdrBasicTypesTest, one_inner_struct)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x2E, // DHEADER
         0x50, 0x00, 0x00, 0x01, // EMHEADER1(M) with NEXTINT
         0x00, 0x00, 0x00, 0x0E, // NEXTINT + DHEADER
@@ -11344,7 +11351,7 @@ TEST_P(XCdrBasicTypesTest, one_inner_struct)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x2E, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x50, // EMHEADER1(M) with NEXTINT
         0x0E, 0x00, 0x00, 0x00, // NEXTINT + DHEADER
@@ -11396,6 +11403,7 @@ TEST_P(XCdrBasicTypesTest, one_inner_struct)
         cdr.serialize_member(MemberId(1), value);
         cdr.serialize_member(MemberId(2), value);
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 
@@ -11475,6 +11483,7 @@ TEST_P(XCdrBasicTypesTest, one_inner_struct)
         cdr << MemberId(1) << value;
         cdr << MemberId(2) << value;
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 
@@ -11685,7 +11694,7 @@ TEST_P(XCdrBasicTypesTest, two_inner_struct)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x1e, // DHEADER
         0x00, 0x00, 0x00, 0x0A, // DHEADER
         0x00, 0x00, 0x00, 0x04, // DHEADER
@@ -11701,7 +11710,7 @@ TEST_P(XCdrBasicTypesTest, two_inner_struct)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x1e, 0x00, 0x00, 0x00, // DHEADER
         0x0A, 0x00, 0x00, 0x00, // DHEADER
         0x04, 0x00, 0x00, 0x00, // DHEADER
@@ -11717,7 +11726,7 @@ TEST_P(XCdrBasicTypesTest, two_inner_struct)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x4e, // DHEADER
         0x50, 0x00, 0x00, 0x01, // EMHEADER1(M) with NEXTINT
         0x00, 0x00, 0x00, 0x1e, // NEXTINT + DHEADER
@@ -11747,7 +11756,7 @@ TEST_P(XCdrBasicTypesTest, two_inner_struct)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x4e, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x50, // EMHEADER1(M) with NEXTINT
         0x1e, 0x00, 0x00, 0x00, // NEXTINT + DHEADER
@@ -11809,6 +11818,7 @@ TEST_P(XCdrBasicTypesTest, two_inner_struct)
         cdr.serialize_member(MemberId(1), value);
         cdr.serialize_member(MemberId(2), value);
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 
@@ -11888,6 +11898,7 @@ TEST_P(XCdrBasicTypesTest, two_inner_struct)
         cdr << MemberId(1) << value;
         cdr << MemberId(2) << value;
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 

--- a/test/xcdr/external.cpp
+++ b/test/xcdr/external.cpp
@@ -453,13 +453,13 @@ void serialize_external(
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x03, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x01, // Encapsulation
         0x03, 0x00, 0x00, 0x00, // String length
         valA, valB, 0x00        // String
     };
@@ -487,19 +487,19 @@ void serialize_external(
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x03, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x01, // Encapsulation
         0x03, 0x00, 0x00, 0x00, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x0B, // DHEADER
         0x00, 0x00, 0x00, 0x07, // DHEADER
         0x00, 0x00, 0x00, 0x03, // String length
@@ -507,7 +507,7 @@ void serialize_external(
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x01, // Encapsulation
         0x0B, 0x00, 0x00, 0x00, // DHEADER
         0x07, 0x00, 0x00, 0x00, // DHEADER
         0x03, 0x00, 0x00, 0x00, // String length
@@ -515,7 +515,7 @@ void serialize_external(
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x13, // DHEADER
         0x50, 0x00, 0x00, 0x01, // EMHEADER1(M) with NEXTINT
         0x00, 0x00, 0x00, 0x0B, // DHEADER
@@ -525,7 +525,7 @@ void serialize_external(
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x01, // Encapsulation
         0x13, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x50, // EMHEADER1(M) with NEXTINT
         0x0B, 0x00, 0x00, 0x00, // DHEADER
@@ -567,6 +567,7 @@ void serialize_external(
         cdr << MemberId(1) << ext_value;
     }
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -621,14 +622,14 @@ void serialize_optional_external(
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x01, // Encapsulation
         0x00, 0x01, 0x00, 0x07, // ShortMemberHeader
         0x00, 0x00, 0x00, 0x03, // String length
         valA, valB, 0x00        // String
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x01, // Encapsulation
         0x01, 0x00, 0x07, 0x00, // ShortMemberHeader
         0x03, 0x00, 0x00, 0x00, // String length
         valA, valB, 0x00        // String
@@ -657,7 +658,7 @@ void serialize_optional_external(
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x01, // Encapsulation
         0x01,                   // Present
         0x00, 0x00, 0x00,       // Alignment
         0x00, 0x00, 0x00, 0x03, // String length
@@ -665,7 +666,7 @@ void serialize_optional_external(
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x01, // Encapsulation
         0x01,                   // Present
         0x00, 0x00, 0x00,       // Alignment
         0x03, 0x00, 0x00, 0x00, // String length
@@ -673,7 +674,7 @@ void serialize_optional_external(
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x0F, // DHEADER
         0x01,                   // Present
         0x00, 0x00, 0x00,       // Alignment
@@ -683,7 +684,7 @@ void serialize_optional_external(
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x01, // Encapsulation
         0x0F, 0x00, 0x00, 0x00, // DHEADER
         0x01,                   // Present
         0x00, 0x00, 0x00,       // Alignment
@@ -693,7 +694,7 @@ void serialize_optional_external(
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x13, // DHEADER
         0x50, 0x00, 0x00, 0x01, // EMHEADER1(M) with NEXTINT
         0x00, 0x00, 0x00, 0x0B, // DHEADER
@@ -703,7 +704,7 @@ void serialize_optional_external(
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x01, // Encapsulation
         0x13, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x50, // EMHEADER1(M) with NEXTINT
         0x0B, 0x00, 0x00, 0x00, // DHEADER
@@ -745,6 +746,7 @@ void serialize_optional_external(
         cdr << MemberId(1) << ext_value;
     }
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -1006,23 +1008,23 @@ TEST_P(XCdrExternalTest, null_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x03, // Encapsulation
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x03, // Encapsulation
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x01, // DHEADER
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x03, // Encapsulation
         0x01, 0x00, 0x00, 0x00, // DHEADER
         0x00                    // Not present
     };
@@ -1069,6 +1071,7 @@ TEST_P(XCdrExternalTest, null_optional)
         cdr.begin_serialize_type(enc_state, encoding);
         cdr.serialize_member(MemberId(1), opt_value);
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 
@@ -1119,6 +1122,7 @@ TEST_P(XCdrExternalTest, null_optional)
         cdr.begin_serialize_type(enc_state, encoding);
         cdr << MemberId(1) << opt_value;
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 

--- a/test/xcdr/final.cpp
+++ b/test/xcdr/final.cpp
@@ -170,7 +170,7 @@ TEST_P(XCdrFinalTest, inner_appendable_structure)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, ival, // ULong
         0x00, 0x00, 0x00, 0x05, // DHEADER
         0x00, 0x00, 0x00, ival, // ULong
@@ -178,7 +178,7 @@ TEST_P(XCdrFinalTest, inner_appendable_structure)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x03, // Encapsulation
         ival, 0x00, 0x00, 0x00, // ULong
         0x05, 0x00, 0x00, 0x00, // DHEADER
         ival, 0x00, 0x00, 0x00, // ULong
@@ -209,6 +209,7 @@ TEST_P(XCdrFinalTest, inner_appendable_structure)
     cdr << MemberId(1) << value1;
     cdr << MemberId(2) << value2;
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -337,6 +338,7 @@ TEST_P(XCdrFinalTest, inner_mutable_structure)
     cdr << MemberId(1) << value1;
     cdr << MemberId(2) << value2;
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 

--- a/test/xcdr/mutable.cpp
+++ b/test/xcdr/mutable.cpp
@@ -338,7 +338,7 @@ TEST_P(XCdrMutableTest, unordered_and_more_serialized_elements)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x16, // DHEADER
         0x20, 0x00, 0x00, 0x03, // EMHEADER1(M) without NEXTINT
         0x00, 0x00, 0x00, ival, // ULong
@@ -350,7 +350,7 @@ TEST_P(XCdrMutableTest, unordered_and_more_serialized_elements)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x16, 0x00, 0x00, 0x00, // DHEADER
         0x03, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         ival, 0x00, 0x00, 0x00, // ULong
@@ -386,6 +386,7 @@ TEST_P(XCdrMutableTest, unordered_and_more_serialized_elements)
     cdr << MemberId(0x3FFF) << value3;
     cdr << MemberId(16) << value2;
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -480,7 +481,7 @@ TEST_P(XCdrMutableTest, unordered_and_less_serialized_elements)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x20, 0x00, 0x00, 0x03, // EMHEADER1(M) without NEXTINT
         0x00, 0x00, 0x00, ival, // ULong
@@ -489,7 +490,7 @@ TEST_P(XCdrMutableTest, unordered_and_less_serialized_elements)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x03, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         ival, 0x00, 0x00, 0x00, // ULong
@@ -520,6 +521,7 @@ TEST_P(XCdrMutableTest, unordered_and_less_serialized_elements)
     cdr << MemberId(3) << value1;
     cdr << MemberId(16) << value2;
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -667,7 +669,7 @@ TEST_P(XCdrMutableTest, inner_unordered_and_more_serialized_elements)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x3E, // DHEADER
         0x50, 0x00, 0x00, 0x01, // EMHEADER1(M) with NEXTINT
         0x00, 0x00, 0x00, 0x16, // NEXTINT + DHEADER
@@ -691,7 +693,7 @@ TEST_P(XCdrMutableTest, inner_unordered_and_more_serialized_elements)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x3E, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x50, // EMHEADER1(M) with NEXTINT
         0x16, 0x00, 0x00, 0x00, // NEXTINT + DHEADER
@@ -736,6 +738,7 @@ TEST_P(XCdrMutableTest, inner_unordered_and_more_serialized_elements)
     cdr << MemberId(1) << value;
     cdr << MemberId(2) << value;
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -856,7 +859,7 @@ TEST_P(XCdrMutableTest, inner_unordered_and_less_serialized_elements)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x2E, // DHEADER
         0x50, 0x00, 0x00, 0x01, // EMHEADER1(M) with NEXTINT
         0x00, 0x00, 0x00, 0x0E, // NEXTINT + DHEADER
@@ -874,7 +877,7 @@ TEST_P(XCdrMutableTest, inner_unordered_and_less_serialized_elements)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x2E, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x50, // EMHEADER1(M) with NEXTINT
         0x0E, 0x00, 0x00, 0x00, // NEXTINT + DHEADER
@@ -913,6 +916,7 @@ TEST_P(XCdrMutableTest, inner_unordered_and_less_serialized_elements)
     cdr << MemberId(1) << value;
     cdr << MemberId(2) << value;
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -1004,7 +1008,7 @@ TEST_P(XCdrMutableTest, inner_final_structure)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x15, // DHEADER
         0x20, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         0x00, 0x00, 0x00, ival, // ULong
@@ -1015,7 +1019,7 @@ TEST_P(XCdrMutableTest, inner_final_structure)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x15, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         ival, 0x00, 0x00, 0x00, // ULong
@@ -1049,6 +1053,7 @@ TEST_P(XCdrMutableTest, inner_final_structure)
     cdr << MemberId(1) << value1;
     cdr << MemberId(2) << value2;
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -1142,7 +1147,7 @@ TEST_P(XCdrMutableTest, inner_appendable_structure)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x15, // DHEADER
         0x20, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         0x00, 0x00, 0x00, ival, // ULong
@@ -1153,7 +1158,7 @@ TEST_P(XCdrMutableTest, inner_appendable_structure)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x15, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         ival, 0x00, 0x00, 0x00, // ULong
@@ -1187,6 +1192,7 @@ TEST_P(XCdrMutableTest, inner_appendable_structure)
     cdr << MemberId(1) << value1;
     cdr << MemberId(2) << value2;
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 

--- a/test/xcdr/optional.cpp
+++ b/test/xcdr/optional.cpp
@@ -172,6 +172,7 @@ void serialize_optional(
         cdr << MemberId(1) << opt_value;
     }
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -258,6 +259,7 @@ void null_align_serialize_optional(
         cdr << MemberId(0) << align_value << MemberId(1) << opt_value;
     }
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -362,6 +364,7 @@ void align_serialize_optional(
         cdr << MemberId(0) << align_value << MemberId(1) << opt_value;
     }
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -470,6 +473,7 @@ void longdouble_align_serialize_optional(
         cdr << MemberId(0) << align_value << MemberId(1) << opt_value;
     }
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -588,23 +592,23 @@ TEST_P(XCdrOptionalTest, null_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x03, // Encapsulation
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x03, // Encapsulation
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x01, // DHEADER
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x03, // Encapsulation
         0x01, 0x00, 0x00, 0x00, // DHEADER
         0x00                    // Not present
     };
@@ -651,6 +655,7 @@ TEST_P(XCdrOptionalTest, null_optional)
         cdr.begin_serialize_type(enc_state, encoding);
         cdr.serialize_member(MemberId(1), opt_value);
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 
@@ -701,6 +706,7 @@ TEST_P(XCdrOptionalTest, null_optional)
         cdr.begin_serialize_type(enc_state, encoding);
         cdr << MemberId(1) << opt_value;
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 
@@ -756,13 +762,13 @@ TEST_P(XCdrOptionalTest, short_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         0x00, 0x01, 0x00, 0x02, // ShortMemberHeader
         ival, fval              // Short
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         0x01, 0x00, 0x02, 0x00, // ShortMemberHeader
         fval, ival              // Short
     };
@@ -810,14 +816,14 @@ TEST_P(XCdrOptionalTest, short_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         0x10, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         ival, fval              // Short
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fval, ival              // Short
@@ -852,13 +858,13 @@ TEST_P(XCdrOptionalTest, ushort_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         0x00, 0x01, 0x00, 0x02, // ShortMemberHeader
         ival, fval              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         0x01, 0x00, 0x02, 0x00, // ShortMemberHeader
         fval, ival              // UShort
     };
@@ -906,14 +912,14 @@ TEST_P(XCdrOptionalTest, ushort_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         0x10, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         ival, fval              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fval, ival              // UShort
@@ -1688,6 +1694,7 @@ TEST_P(XCdrOptionalTest, longdouble_optional)
         cdr.begin_serialize_type(enc_state, encoding);
         cdr.serialize_member(MemberId(1), opt_value);
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 
@@ -1747,6 +1754,7 @@ TEST_P(XCdrOptionalTest, longdouble_optional)
         cdr.begin_serialize_type(enc_state, encoding);
         cdr << MemberId(1) << opt_value;
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 
@@ -1808,13 +1816,13 @@ TEST_P(XCdrOptionalTest, boolean_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         0x00, 0x01, 0x00, 0x01, // ShortMemberHeader
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         0x01, 0x00, 0x01, 0x00, // ShortMemberHeader
         b_value                 // Boolean
     };
@@ -1836,40 +1844,40 @@ TEST_P(XCdrOptionalTest, boolean_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         0x01,                   // Present
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         0x01,                   // Present
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x02, // DHEADER
         0x01,                   // Present
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x02, 0x00, 0x00, 0x00, // DHEADER
         0x01,                   // Present
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x05, // DHEADER
         0x00, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         b_value                 // Boolean
@@ -1902,13 +1910,13 @@ TEST_P(XCdrOptionalTest, octet_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         0x00, 0x01, 0x00, 0x01, // ShortMemberHeader
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         0x01, 0x00, 0x01, 0x00, // ShortMemberHeader
         octet_value             // Octet
     };
@@ -1930,40 +1938,40 @@ TEST_P(XCdrOptionalTest, octet_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         0x01,                   // Present
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         0x01,                   // Present
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x02, // DHEADER
         0x01,                   // Present
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x02, 0x00, 0x00, 0x00, // DHEADER
         0x01,                   // Present
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x05, // DHEADER
         0x00, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         octet_value             // Octet
@@ -1997,13 +2005,13 @@ TEST_P(XCdrOptionalTest, char_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         0x00, 0x01, 0x00, 0x01, // ShortMemberHeader
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         0x01, 0x00, 0x01, 0x00, // ShortMemberHeader
         valu                    // Char
     };
@@ -2025,40 +2033,40 @@ TEST_P(XCdrOptionalTest, char_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         0x01,                   // Present
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         0x01,                   // Present
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x02, // DHEADER
         0x01,                   // Present
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x02, 0x00, 0x00, 0x00, // DHEADER
         0x01,                   // Present
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x05, // DHEADER
         0x00, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         valu                    // Char
@@ -2093,13 +2101,13 @@ TEST_P(XCdrOptionalTest, wchar_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         0x00, 0x01, 0x00, 0x02, // ShortMemberHeader
         ival, fval              // Wchar
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         0x01, 0x00, 0x02, 0x00, // ShortMemberHeader
         fval, ival              // Wchar
     };
@@ -2151,14 +2159,14 @@ TEST_P(XCdrOptionalTest, wchar_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         0x10, 0x00, 0x00, 0x01, // EMHEADER1(M) without NEXTINT
         ival, fval              // Wchar
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fval, ival              // Wchar
@@ -2222,40 +2230,40 @@ TEST_P(XCdrOptionalTest, null_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         align_value,
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         align_value,
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x02, // DHEADER
         align_value,
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x02, 0x00, 0x00, 0x00, // DHEADER
         align_value,
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x05, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value
@@ -2322,40 +2330,40 @@ TEST_P(XCdrOptionalTest, null_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x01, // Encapsulation
         ival, fval,
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x01, // Encapsulation
         fval, ival,
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x03, // DHEADER
         ival, fval,
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x01, // Encapsulation
         0x03, 0x00, 0x00, 0x00, // DHEADER
         fval, ival,
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         0x10, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         ival, fval
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fval, ival
@@ -2417,26 +2425,26 @@ TEST_P(XCdrOptionalTest, null_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x03, // Encapsulation
         ival, ival, ival, fval,
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x03, // Encapsulation
         fval, ival, ival, ival,
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x05, // DHEADER
         ival, ival, ival, fval,
         0x00                    // Not present
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         fval, ival, ival, ival,
         0x00                    // Not present
@@ -2487,7 +2495,7 @@ TEST_P(XCdrOptionalTest, short_align_1_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         align_value,
         0x00, 0x00, 0x00,       // Alignment
         0x00, 0x01, 0x00, 0x02, // ShortMemberHeader
@@ -2495,7 +2503,7 @@ TEST_P(XCdrOptionalTest, short_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         align_value,
         0x00, 0x00, 0x00,       // Alignment
         0x01, 0x00, 0x02, 0x00, // ShortMemberHeader
@@ -2555,7 +2563,7 @@ TEST_P(XCdrOptionalTest, short_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -2565,7 +2573,7 @@ TEST_P(XCdrOptionalTest, short_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -2606,7 +2614,7 @@ TEST_P(XCdrOptionalTest, short_align_2_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         iava, fava,
         0x00, 0x00,             // Alignment
         0x00, 0x01, 0x00, 0x02, // ShortMemberHeader
@@ -2614,7 +2622,7 @@ TEST_P(XCdrOptionalTest, short_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         fava, iava,
         0x00, 0x00,             // Alignment
         0x01, 0x00, 0x02, 0x00, // ShortMemberHeader
@@ -2644,7 +2652,7 @@ TEST_P(XCdrOptionalTest, short_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         iava, fava,
         0x01,                   // Present
         0x00,                   // Alignment
@@ -2652,7 +2660,7 @@ TEST_P(XCdrOptionalTest, short_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         fava, iava,
         0x01,                   // Present
         0x00,                   // Alignment
@@ -2660,7 +2668,7 @@ TEST_P(XCdrOptionalTest, short_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         iava, fava,
         0x01,                   // Present
@@ -2669,7 +2677,7 @@ TEST_P(XCdrOptionalTest, short_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         fava, iava,
         0x01,                   // Present
@@ -2678,7 +2686,7 @@ TEST_P(XCdrOptionalTest, short_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x10, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, fava,
@@ -2688,7 +2696,7 @@ TEST_P(XCdrOptionalTest, short_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fava, iava,
@@ -2730,14 +2738,14 @@ TEST_P(XCdrOptionalTest, short_align_4_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         iava, iava, iava, fava,
         0x00, 0x01, 0x00, 0x02, // ShortMemberHeader
         ival, fval              // Short
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         fava, iava, iava, iava,
         0x01, 0x00, 0x02, 0x00, // ShortMemberHeader
         fval, ival              // Short
@@ -2798,7 +2806,7 @@ TEST_P(XCdrOptionalTest, short_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, iava, iava, fava,
@@ -2807,7 +2815,7 @@ TEST_P(XCdrOptionalTest, short_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         fava, iava, iava, iava,
@@ -2846,7 +2854,7 @@ TEST_P(XCdrOptionalTest, ushort_align_1_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         align_value,
         0x00, 0x00, 0x00,       // Alignment
         0x00, 0x01, 0x00, 0x02, // ShortMemberHeader
@@ -2854,7 +2862,7 @@ TEST_P(XCdrOptionalTest, ushort_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         align_value,
         0x00, 0x00, 0x00,       // Alignment
         0x01, 0x00, 0x02, 0x00, // ShortMemberHeader
@@ -2914,7 +2922,7 @@ TEST_P(XCdrOptionalTest, ushort_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -2924,7 +2932,7 @@ TEST_P(XCdrOptionalTest, ushort_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -2966,7 +2974,7 @@ TEST_P(XCdrOptionalTest, ushort_align_2_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         iava, fava,
         0x00, 0x00,             // Alignment
         0x00, 0x01, 0x00, 0x02, // ShortMemberHeader
@@ -2974,7 +2982,7 @@ TEST_P(XCdrOptionalTest, ushort_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         fava, iava,
         0x00, 0x00,             // Alignment
         0x01, 0x00, 0x02, 0x00, // ShortMemberHeader
@@ -3004,7 +3012,7 @@ TEST_P(XCdrOptionalTest, ushort_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         iava, fava,
         0x01,                   // Present
         0x00,                   // Alignment
@@ -3012,7 +3020,7 @@ TEST_P(XCdrOptionalTest, ushort_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         fava, iava,
         0x01,                   // Present
         0x00,                   // Alignment
@@ -3020,7 +3028,7 @@ TEST_P(XCdrOptionalTest, ushort_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         iava, fava,
         0x01,                   // Present
@@ -3029,7 +3037,7 @@ TEST_P(XCdrOptionalTest, ushort_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         fava, iava,
         0x01,                   // Present
@@ -3038,7 +3046,7 @@ TEST_P(XCdrOptionalTest, ushort_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x10, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, fava,
@@ -3048,7 +3056,7 @@ TEST_P(XCdrOptionalTest, ushort_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fava, iava,
@@ -3090,14 +3098,14 @@ TEST_P(XCdrOptionalTest, ushort_align_4_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         iava, iava, iava, fava,
         0x00, 0x01, 0x00, 0x02, // ShortMemberHeader
         ival, fval              // UShort
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         fava, iava, iava, iava,
         0x01, 0x00, 0x02, 0x00, // ShortMemberHeader
         fval, ival              // UShort
@@ -3158,7 +3166,7 @@ TEST_P(XCdrOptionalTest, ushort_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, iava, iava, fava,
@@ -3167,7 +3175,7 @@ TEST_P(XCdrOptionalTest, ushort_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         fava, iava, iava, iava,
@@ -5867,7 +5875,7 @@ TEST_P(XCdrOptionalTest, boolean_align_1_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         align_value,
         0x00, 0x00, 0x00,       // Alignment
         0x00, 0x01, 0x00, 0x01, // ShortMemberHeader
@@ -5875,7 +5883,7 @@ TEST_P(XCdrOptionalTest, boolean_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         align_value,
         0x00, 0x00, 0x00,       // Alignment
         0x01, 0x00, 0x01, 0x00, // ShortMemberHeader
@@ -5905,21 +5913,21 @@ TEST_P(XCdrOptionalTest, boolean_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x01, // Encapsulation
         align_value,
         0x01,                   // Present
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x01, // Encapsulation
         align_value,
         0x01,                   // Present
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x03, // DHEADER
         align_value,
         0x01,                   // Present
@@ -5927,7 +5935,7 @@ TEST_P(XCdrOptionalTest, boolean_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x01, // Encapsulation
         0x03, 0x00, 0x00, 0x00, // DHEADER
         align_value,
         0x01,                   // Present
@@ -5935,7 +5943,7 @@ TEST_P(XCdrOptionalTest, boolean_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -5945,7 +5953,7 @@ TEST_P(XCdrOptionalTest, boolean_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -5986,7 +5994,7 @@ TEST_P(XCdrOptionalTest, boolean_align_2_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         iava, fava,
         0x00, 0x00,             // Alignment
         0x00, 0x01, 0x00, 0x01, // ShortMemberHeader
@@ -5994,7 +6002,7 @@ TEST_P(XCdrOptionalTest, boolean_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         fava, iava,
         0x00, 0x00,             // Alignment
         0x01, 0x00, 0x01, 0x00, // ShortMemberHeader
@@ -6054,7 +6062,7 @@ TEST_P(XCdrOptionalTest, boolean_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x10, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, fava,
@@ -6064,7 +6072,7 @@ TEST_P(XCdrOptionalTest, boolean_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fava, iava,
@@ -6105,14 +6113,14 @@ TEST_P(XCdrOptionalTest, boolean_align_4_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         iava, iava, iava, fava,
         0x00, 0x01, 0x00, 0x01, // ShortMemberHeader
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         fava, iava, iava, iava,
         0x01, 0x00, 0x01, 0x00, // ShortMemberHeader
         b_value                 // Boolean
@@ -6139,21 +6147,21 @@ TEST_P(XCdrOptionalTest, boolean_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         iava, iava, iava, fava,
         0x01,                   // Present
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         fava, iava, iava, iava,
         0x01,                   // Present
         b_value                 // Boolean
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         iava, iava, iava, fava,
         0x01,                   // Present
@@ -6161,7 +6169,7 @@ TEST_P(XCdrOptionalTest, boolean_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         fava, iava, iava, iava,
         0x01,                   // Present
@@ -6169,7 +6177,7 @@ TEST_P(XCdrOptionalTest, boolean_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, iava, iava, fava,
@@ -6178,7 +6186,7 @@ TEST_P(XCdrOptionalTest, boolean_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         fava, iava, iava, iava,
@@ -6215,7 +6223,7 @@ TEST_P(XCdrOptionalTest, octet_align_1_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         align_value,
         0x00, 0x00, 0x00,       // Alignment
         0x00, 0x01, 0x00, 0x01, // ShortMemberHeader
@@ -6223,7 +6231,7 @@ TEST_P(XCdrOptionalTest, octet_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         align_value,
         0x00, 0x00, 0x00,       // Alignment
         0x01, 0x00, 0x01, 0x00, // ShortMemberHeader
@@ -6253,21 +6261,21 @@ TEST_P(XCdrOptionalTest, octet_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x01, // Encapsulation
         align_value,
         0x01,                   // Present
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x01, // Encapsulation
         align_value,
         0x01,                   // Present
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x03, // DHEADER
         align_value,
         0x01,                   // Present
@@ -6275,7 +6283,7 @@ TEST_P(XCdrOptionalTest, octet_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x01, // Encapsulation
         0x03, 0x00, 0x00, 0x00, // DHEADER
         align_value,
         0x01,                   // Present
@@ -6283,7 +6291,7 @@ TEST_P(XCdrOptionalTest, octet_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -6293,7 +6301,7 @@ TEST_P(XCdrOptionalTest, octet_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -6333,7 +6341,7 @@ TEST_P(XCdrOptionalTest, octet_align_2_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         iava, fava,
         0x00, 0x00,             // Alignment
         0x00, 0x01, 0x00, 0x01, // ShortMemberHeader
@@ -6341,7 +6349,7 @@ TEST_P(XCdrOptionalTest, octet_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         fava, iava,
         0x00, 0x00,             // Alignment
         0x01, 0x00, 0x01, 0x00, // ShortMemberHeader
@@ -6401,7 +6409,7 @@ TEST_P(XCdrOptionalTest, octet_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x10, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, fava,
@@ -6411,7 +6419,7 @@ TEST_P(XCdrOptionalTest, octet_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fava, iava,
@@ -6451,14 +6459,14 @@ TEST_P(XCdrOptionalTest, octet_align_4_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         iava, iava, iava, fava,
         0x00, 0x01, 0x00, 0x01, // ShortMemberHeader
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         fava, iava, iava, iava,
         0x01, 0x00, 0x01, 0x00, // ShortMemberHeader
         octet_value             // Octet
@@ -6485,21 +6493,21 @@ TEST_P(XCdrOptionalTest, octet_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         iava, iava, iava, fava,
         0x01,                   // Present
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         fava, iava, iava, iava,
         0x01,                   // Present
         octet_value             // Octet
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         iava, iava, iava, fava,
         0x01,                   // Present
@@ -6507,7 +6515,7 @@ TEST_P(XCdrOptionalTest, octet_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         fava, iava, iava, iava,
         0x01,                   // Present
@@ -6515,7 +6523,7 @@ TEST_P(XCdrOptionalTest, octet_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, iava, iava, fava,
@@ -6524,7 +6532,7 @@ TEST_P(XCdrOptionalTest, octet_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         fava, iava, iava, iava,
@@ -6562,7 +6570,7 @@ TEST_P(XCdrOptionalTest, char_align_1_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         align_value,
         0x00, 0x00, 0x00,       // Alignment
         0x00, 0x01, 0x00, 0x01, // ShortMemberHeader
@@ -6570,7 +6578,7 @@ TEST_P(XCdrOptionalTest, char_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         align_value,
         0x00, 0x00, 0x00,       // Alignment
         0x01, 0x00, 0x01, 0x00, // ShortMemberHeader
@@ -6600,21 +6608,21 @@ TEST_P(XCdrOptionalTest, char_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x01, // Encapsulation
         align_value,
         0x01,                   // Present
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x01, // Encapsulation
         align_value,
         0x01,                   // Present
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x01, // Encapsulation
         0x00, 0x00, 0x00, 0x03, // DHEADER
         align_value,
         0x01,                   // Present
@@ -6622,7 +6630,7 @@ TEST_P(XCdrOptionalTest, char_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x01, // Encapsulation
         0x03, 0x00, 0x00, 0x00, // DHEADER
         align_value,
         0x01,                   // Present
@@ -6630,7 +6638,7 @@ TEST_P(XCdrOptionalTest, char_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -6640,7 +6648,7 @@ TEST_P(XCdrOptionalTest, char_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -6681,7 +6689,7 @@ TEST_P(XCdrOptionalTest, char_align_2_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         iava, fava,
         0x00, 0x00,             // Alignment
         0x00, 0x01, 0x00, 0x01, // ShortMemberHeader
@@ -6689,7 +6697,7 @@ TEST_P(XCdrOptionalTest, char_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         fava, iava,
         0x00, 0x00,             // Alignment
         0x01, 0x00, 0x01, 0x00, // ShortMemberHeader
@@ -6749,7 +6757,7 @@ TEST_P(XCdrOptionalTest, char_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x10, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, fava,
@@ -6759,7 +6767,7 @@ TEST_P(XCdrOptionalTest, char_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fava, iava,
@@ -6800,14 +6808,14 @@ TEST_P(XCdrOptionalTest, char_align_4_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x03, // Encapsulation
         iava, iava, iava, fava,
         0x00, 0x01, 0x00, 0x01, // ShortMemberHeader
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x03, // Encapsulation
         fava, iava, iava, iava,
         0x01, 0x00, 0x01, 0x00, // ShortMemberHeader
         valu                    // Char
@@ -6834,21 +6842,21 @@ TEST_P(XCdrOptionalTest, char_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         iava, iava, iava, fava,
         0x01,                   // Present
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         fava, iava, iava, iava,
         0x01,                   // Present
         valu                    // Char
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         iava, iava, iava, fava,
         0x01,                   // Present
@@ -6856,7 +6864,7 @@ TEST_P(XCdrOptionalTest, char_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         fava, iava, iava, iava,
         0x01,                   // Present
@@ -6864,7 +6872,7 @@ TEST_P(XCdrOptionalTest, char_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x0D, // DHEADER
         0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, iava, iava, fava,
@@ -6873,7 +6881,7 @@ TEST_P(XCdrOptionalTest, char_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x03, // Encapsulation
         0x0D, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         fava, iava, iava, iava,
@@ -6912,7 +6920,7 @@ TEST_P(XCdrOptionalTest, wchar_align_1_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         align_value,
         0x00, 0x00, 0x00,       // Alignment
         0x00, 0x01, 0x00, 0x02, // ShortMemberHeader
@@ -6920,7 +6928,7 @@ TEST_P(XCdrOptionalTest, wchar_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         align_value,
         0x00, 0x00, 0x00,       // Alignment
         0x01, 0x00, 0x02, 0x00, // ShortMemberHeader
@@ -6980,7 +6988,7 @@ TEST_P(XCdrOptionalTest, wchar_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -6990,7 +6998,7 @@ TEST_P(XCdrOptionalTest, wchar_align_1_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         align_value,
@@ -7032,7 +7040,7 @@ TEST_P(XCdrOptionalTest, wchar_align_2_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         iava, fava,
         0x00, 0x00,             // Alignment
         0x00, 0x01, 0x00, 0x02, // ShortMemberHeader
@@ -7040,7 +7048,7 @@ TEST_P(XCdrOptionalTest, wchar_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         fava, iava,
         0x00, 0x00,             // Alignment
         0x01, 0x00, 0x02, 0x00, // ShortMemberHeader
@@ -7070,7 +7078,7 @@ TEST_P(XCdrOptionalTest, wchar_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x06, 0x00, 0x00, // Encapsulation
+        0x00, 0x06, 0x00, 0x02, // Encapsulation
         iava, fava,
         0x01,                   // Present
         0x00,                   // Alignment
@@ -7078,7 +7086,7 @@ TEST_P(XCdrOptionalTest, wchar_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x07, 0x00, 0x00, // Encapsulation
+        0x00, 0x07, 0x00, 0x02, // Encapsulation
         fava, iava,
         0x01,                   // Present
         0x00,                   // Alignment
@@ -7086,7 +7094,7 @@ TEST_P(XCdrOptionalTest, wchar_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x06, // DHEADER
         iava, fava,
         0x01,                   // Present
@@ -7095,7 +7103,7 @@ TEST_P(XCdrOptionalTest, wchar_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x02, // Encapsulation
         0x06, 0x00, 0x00, 0x00, // DHEADER
         fava, iava,
         0x01,                   // Present
@@ -7104,7 +7112,7 @@ TEST_P(XCdrOptionalTest, wchar_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x10, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, fava,
@@ -7114,7 +7122,7 @@ TEST_P(XCdrOptionalTest, wchar_align_2_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x10, // EMHEADER1(M) without NEXTINT
         fava, iava,
@@ -7156,14 +7164,14 @@ TEST_P(XCdrOptionalTest, wchar_align_4_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         iava, iava, iava, fava,
         0x00, 0x01, 0x00, 0x02, // ShortMemberHeader
         ival, fval              // WChar
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         fava, iava, iava, iava,
         0x01, 0x00, 0x02, 0x00, // ShortMemberHeader
         fval, ival              // WChar
@@ -7224,7 +7232,7 @@ TEST_P(XCdrOptionalTest, wchar_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x0E, // DHEADER
         0x20, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         iava, iava, iava, fava,
@@ -7233,7 +7241,7 @@ TEST_P(XCdrOptionalTest, wchar_align_4_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x0E, 0x00, 0x00, 0x00, // DHEADER
         0x00, 0x00, 0x00, 0x20, // EMHEADER1(M) without NEXTINT
         fava, iava, iava, iava,
@@ -7324,7 +7332,7 @@ TEST_P(XCdrOptionalTest, two_inner_null_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x08, 0x00, 0x00, // Encapsulation
+        0x00, 0x08, 0x00, 0x03, // Encapsulation
         0x00, 0x00, 0x00, 0x11, // DHEADER
         0x01,                   // Present
         0x00, 0x00, 0x00,       // Alignment
@@ -7337,7 +7345,7 @@ TEST_P(XCdrOptionalTest, two_inner_null_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::DELIMIT_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x09, 0x00, 0x00, // Encapsulation
+        0x00, 0x09, 0x00, 0x03, // Encapsulation
         0x11, 0x00, 0x00, 0x00, // DHEADER
         0x01,                   // Present
         0x00, 0x00, 0x00,       // Alignment
@@ -7400,6 +7408,7 @@ TEST_P(XCdrOptionalTest, two_inner_null_optional)
         cdr.serialize_member(MemberId(1), opt_value);
         cdr.serialize_member(MemberId(3), opt_value);
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 
@@ -7482,6 +7491,7 @@ TEST_P(XCdrOptionalTest, two_inner_null_optional)
         cdr << MemberId(1) << opt_value;
         cdr << MemberId(3) << opt_value;
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 
@@ -7575,7 +7585,7 @@ TEST_P(XCdrOptionalTest, two_inner_short_optional)
     XCdrStreamValues expected_streams;
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x00, 0x00, 0x02, // Encapsulation
         0x00, 0x01, 0x00, 0x06, // ShortMemberHeader
         0x00, 0x03, 0x00, 0x02, // ShortMemberHeader
         ival, fval,             // Short
@@ -7586,7 +7596,7 @@ TEST_P(XCdrOptionalTest, two_inner_short_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x02, // Encapsulation
         0x01, 0x00, 0x06, 0x00, // ShortMemberHeader
         0x03, 0x00, 0x02, 0x00, // ShortMemberHeader
         fval, ival,             // Short
@@ -7681,7 +7691,7 @@ TEST_P(XCdrOptionalTest, two_inner_short_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::BIG_ENDIANNESS] =
     {
-        0x00, 0x0A, 0x00, 0x00, // Encapsulation
+        0x00, 0x0A, 0x00, 0x02, // Encapsulation
         0x00, 0x00, 0x00, 0x1E, // DHEADER
         0x50, 0x00, 0x00, 0x01, // EMHEADER1(M) with NEXTINT
         0x00, 0x00, 0x00, 0x06, // NEXTINT + DHEADER
@@ -7695,7 +7705,7 @@ TEST_P(XCdrOptionalTest, two_inner_short_optional)
     };
     expected_streams[0 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS] =
     {
-        0x00, 0x0B, 0x00, 0x00, // Encapsulation
+        0x00, 0x0B, 0x00, 0x02, // Encapsulation
         0x1E, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x50, // EMHEADER1(M) with NEXTINT
         0x06, 0x00, 0x00, 0x00, // NEXTINT + DHEADER
@@ -7741,6 +7751,7 @@ TEST_P(XCdrOptionalTest, two_inner_short_optional)
         cdr.serialize_member(MemberId(1), opt_value);
         cdr.serialize_member(MemberId(3), opt_value);
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 
@@ -7823,6 +7834,7 @@ TEST_P(XCdrOptionalTest, two_inner_short_optional)
         cdr << MemberId(1) << opt_value;
         cdr << MemberId(3) << opt_value;
         cdr.end_serialize_type(enc_state);
+        cdr.set_dds_cdr_options({0, 0});
         Cdr::state enc_state_end(cdr);
         //}
 

--- a/test/xcdr/xcdrv1.cpp
+++ b/test/xcdr/xcdrv1.cpp
@@ -65,6 +65,7 @@ void xcdrv1_serialize_the_value(
     cdr.begin_serialize_type(enc_state, encoding);
     cdr.serialize_member(MemberId(1), value, header_selection);
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -132,6 +133,7 @@ TEST_P(XCdrv1Test, auto_selection_on_decode)
     cdr << MemberId(0) << us;
     cdr << MemberId(1) << ul;
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     //}
 
     //{ Decode an ushort and an ulong.
@@ -258,6 +260,7 @@ TEST_P(XCdrv1Test, push_origin_zero)
     cdr << MemberId(0) << uc;
     cdr << MemberId(1) << longlong_value;
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     //}
 
     //{ Test encoded content

--- a/test/xcdr/xcdrv2.cpp
+++ b/test/xcdr/xcdrv2.cpp
@@ -63,6 +63,7 @@ void xcdrv2_serialize_the_value(
     cdr.begin_serialize_type(enc_state, encoding);
     cdr.serialize_member(MemberId(1), value, header_selection);
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     Cdr::state enc_state_end(cdr);
     //}
 
@@ -132,6 +133,7 @@ TEST_P(XCdrv2Test, auto_selection_on_decode)
     cdr << MemberId(0) << us;
     cdr << MemberId(1) << ul;
     cdr.end_serialize_type(enc_state);
+    cdr.set_dds_cdr_options({0, 0});
     //}
 
     //{ Decode an ushort and an ulong.
@@ -181,14 +183,14 @@ TEST_P(XCdrv2PLTest, pl_octet_member)
     XCdrStreamValues expected_streams;
     expected_streams[0 + Cdr::XCdrHeaderSelection::SHORT_HEADER] =
     {
-        0x00, 0x0b, 0x00, 0x00, // Encapsulation
+        0x00, 0x0b, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         octet_value             // Octet
     };
     expected_streams[0 + Cdr::XCdrHeaderSelection::LONG_HEADER] =
     {
-        0x00, 0x0b, 0x00, 0x00, // Encapsulation
+        0x00, 0x0b, 0x00, 0x03, // Encapsulation
         0x09, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x40, // EMHEADER1(M) with NEXTINT
         0x01, 0x00, 0x00, 0x00, // Member size
@@ -196,14 +198,14 @@ TEST_P(XCdrv2PLTest, pl_octet_member)
     };
     expected_streams[0 + Cdr::XCdrHeaderSelection::AUTO_WITH_SHORT_HEADER_BY_DEFAULT] =
     {
-        0x00, 0x0b, 0x00, 0x00, // Encapsulation
+        0x00, 0x0b, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         octet_value             // Octet
     };
     expected_streams[0 + Cdr::XCdrHeaderSelection::AUTO_WITH_LONG_HEADER_BY_DEFAULT] =
     {
-        0x00, 0x0b, 0x00, 0x00, // Encapsulation
+        0x00, 0x0b, 0x00, 0x03, // Encapsulation
         0x05, 0x00, 0x00, 0x00, // DHEADER
         0x01, 0x00, 0x00, 0x00, // EMHEADER1(M) without NEXTINT
         octet_value             // Octet


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
According to DDS X-Types 1.3, least significant two bits should contain the possible padding in a encoded stream. This PR adds this functionality.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.1.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- *N/A* Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: CI pass and failing tests are unrelated with the changes.

