### PR TITLE
[22329] Serialize single null-character for empty strings

### DIFF
--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -689,12 +689,6 @@ public:
     Cdr& serialize(
             const std::string& string_t)
     {
-        // An empty string is serialized as a 0 length string.
-        if (string_t.empty())
-        {
-            return serialize(static_cast<uint32_t>(0));
-        }
-
         // Check there are no null characters in the string.
         const char* c_str = string_t.c_str();
         const auto str_len = strlen(c_str);

--- a/include/fastcdr/FastCdr.h
+++ b/include/fastcdr/FastCdr.h
@@ -891,12 +891,6 @@ public:
     FastCdr& serialize(
             const std::string& string_t)
     {
-        // An empty string is serialized as a 0 length string.
-        if (string_t.empty())
-        {
-            return serialize(static_cast<uint32_t>(0));
-        }
-
         // Check there are no null characters in the string.
         const char* c_str = string_t.c_str();
         const auto str_len = strlen(c_str);

--- a/test/cdr/SimpleTest.cpp
+++ b/test/cdr/SimpleTest.cpp
@@ -7111,3 +7111,29 @@ TEST(FastCDRTests, StringWithNullChars)
     },
         BadParamException);
 }
+
+TEST(CDRTests, EmptyStringSerializationSize)
+{
+    std::string str;
+    char buffer[256];
+    FastBuffer cdrbuffer(buffer, 256);
+    Cdr cdr_ser(cdrbuffer);
+    EXPECT_NO_THROW(
+    {
+        cdr_ser << str;
+    });
+    EXPECT_EQ(cdr_ser.get_serialized_data_length(), 5u);
+}
+
+TEST(FastCDRTests, EmptyStringSerializationSize)
+{
+    std::string str;
+    char buffer[256];
+    FastBuffer cdrbuffer(buffer, 256);
+    FastCdr cdr_ser(cdrbuffer);
+    EXPECT_NO_THROW(
+    {
+        cdr_ser << str;
+    });
+    EXPECT_EQ(cdr_ser.get_serialized_data_length(), 5u);
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

PR #245 introduced a regression that made nightlies of Fast DDS 2.14.x fail. The serialization of empty strings should consist of a length=1 followed by a single null character.

This adds a regression test and removes the check for empty strings in the serialization code.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.1.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: CI pass and failing tests are unrelated with the changes.
