### PR TITLE
[22876] Make `optional` copy/move constructors actuate only if the storage is engaged

### DIFF
--- a/include/fastcdr/xcdr/optional.hpp
+++ b/include/fastcdr/xcdr/optional.hpp
@@ -72,16 +72,22 @@ public:
     optional(
             const optional<T>& val) noexcept
     {
-        ::new(&storage_.val_)T(val.storage_.val_);
-        storage_.engaged_ = val.storage_.engaged_;
+        if (val.storage_.engaged_)
+        {
+            ::new(&storage_.val_)T(val.storage_.val_);
+            storage_.engaged_ = true;
+        }
     }
 
     //! Move constructor.
     optional(
             optional<T>&& val) noexcept
     {
-        ::new(&storage_.val_)T(std::move(val.storage_.val_));
-        storage_.engaged_ = val.storage_.engaged_;
+        if (val.storage_.engaged_)
+        {
+            ::new(&storage_.val_)T(std::move(val.storage_.val_));
+            storage_.engaged_ = true;
+        }
     }
 
     //! Destructor

--- a/test/xcdr/optional.cpp
+++ b/test/xcdr/optional.cpp
@@ -556,6 +556,19 @@ TEST(XCdrOptionalTest, bad_optional_access)
     ASSERT_THROW(opt.value(), exception::BadOptionalAccessException);
 }
 
+TEST(XCdrOptionalTest, optional_no_bad_array_new_length)
+{
+    struct CustomObject
+    {
+        CustomObject() = default;
+
+        std::vector<int32_t> values;
+    };
+
+    optional<CustomObject> src_optional;
+    ASSERT_NO_THROW(optional<CustomObject> dst_optional(src_optional));
+}
+
 /*!
  * @test Test encoding of an empty optional field of octet type
  * @code{.idl}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR makes `optional` copy/move constructors from other optionals to actuate only if the storage to copy from is engaged.
This prevents undefined behavior in the placement new when copying/moving data that is not initialized. 
Specially, it tends to throw `std::bad_array_new_length` when trying to copy vectors.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.2.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: CI pass and failing tests are unrelated with the changes.
