### PR TITLE
[23683] Fix default fixed-string length bug

### DIFF
--- a/include/fastcdr/cdr/fixed_size_string.hpp
+++ b/include/fastcdr/cdr/fixed_size_string.hpp
@@ -85,6 +85,7 @@ public:
         {
             memcpy(string_data, c_array, string_len);
         }
+        string_data[string_len] = '\0';
         return *this;
     }
 

--- a/test/cdr/fixed_size_string.cpp
+++ b/test/cdr/fixed_size_string.cpp
@@ -263,3 +263,36 @@ TEST_F(FixedSizeStringTests, greater_than_operator_std_string)
     ASSERT_FALSE(fixed_string_short > std_string_long);
     ASSERT_TRUE(fixed_string_short > std_string_short);
 }
+
+TEST_F(FixedSizeStringTests, assign)
+{
+    constexpr size_t MAX_FIXED_STRING_SIZE = 10;
+    fixed_string<MAX_FIXED_STRING_SIZE> fixed_s;
+    std::string std_string = "test string";
+    std::string max_allowed_std_string = "test strin";
+    std::string allowed_std_string = "test st";
+
+    ASSERT_TRUE(std_string.size() > MAX_FIXED_STRING_SIZE);
+    ASSERT_TRUE(max_allowed_std_string.size() == MAX_FIXED_STRING_SIZE);
+    ASSERT_TRUE(allowed_std_string.size() < MAX_FIXED_STRING_SIZE);
+
+    fixed_s.assign(std_string.c_str(), std_string.size());
+    ASSERT_EQ(fixed_s.size(), MAX_FIXED_STRING_SIZE);
+    ASSERT_EQ(fixed_s, max_allowed_std_string);
+
+    fixed_s.assign(max_allowed_std_string.c_str(), max_allowed_std_string.size());
+    ASSERT_EQ(fixed_s.size(), MAX_FIXED_STRING_SIZE);
+    ASSERT_EQ(fixed_s, max_allowed_std_string);
+
+    fixed_s.assign(allowed_std_string.c_str(), allowed_std_string.size());
+    ASSERT_EQ(fixed_s.size(), allowed_std_string.size());
+    ASSERT_EQ(fixed_s, allowed_std_string);
+
+    fixed_s.assign(nullptr, 5);
+    ASSERT_EQ(fixed_s.size(), 0u);
+    ASSERT_EQ(fixed_s, "");
+
+    fixed_s.assign(nullptr, 0);
+    ASSERT_EQ(fixed_s.size(), 0u);
+    ASSERT_EQ(fixed_s, "");
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR fixes wrong behavior with fixed strings which had a default value longer than the serialized one.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.2.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- N/A Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- N/A New feature has been added to the `versions.md` file (if applicable).
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: CI pass and failing tests are unrelated with the changes.
