### PR TITLE
[23848] XCDRv1: support extra bytes in optional types

### DIFF
--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -2736,9 +2736,10 @@ public:
             if (member_size < diff)
             {
                 throw exception::BadParamException(
-                          "Member size provided by member header is not equal to the real decoded member size");
+                          "Member size provided by member header is lower than real decoded member size");
             }
 
+            // Skip unused bytes
             offset_ += (member_size - diff);
         }
         else

--- a/test/xcdr/xcdrv1.cpp
+++ b/test/xcdr/xcdrv1.cpp
@@ -461,13 +461,13 @@ INSTANTIATE_TEST_SUITE_P(
         Cdr::XCdrHeaderSelection::AUTO_WITH_LONG_HEADER_BY_DEFAULT
         ));
 
-
 /*!
- * @test Regression test for optional string with extra alignment send by RTI (#23838)
+ * @test Regression test for optional string with extra alignment sent by RTI (#23838)
  * @code{.idl}
  * struct OptinalStringWithExtraAlignment
  * {
  *     @optional string<100> str;
+ *     unsigned short value;
  * };
  * @endcode
  */


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Some XCDRv1 implementations add extra bytes, usually alignment bytes, at the end of the serialized base type of an optional type. And this extra bytes are took into account in the parameter's length which describes the optional. Currently fastcdr doesn't support this. The parameter's length of a optional has to have the exact length of the serialized base type.

This PR introduces this flexibility to support other XCDRv1 implementations.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.2.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: CI pass and failing tests are unrelated with the changes.
