### PR TITLE
Change colcon.pkg dependencies to be test-dependencies.

### DIFF
--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,6 +1,6 @@
 name: fastcdr
 type: cmake
-dependencies:
+test-dependencies:
     # Needed for test compilation in ROS 2 CI
     - ament_cmake_gtest
     - ament_cmake


### PR DESCRIPTION
## Description

The dependencies on ament_cmake, ament_cmake_gtest, and googletest-distribution are only needed when building for tests, so we should only inject them as test dependencies.

I've opened this against the 2.3.x branch (since that is what ROS 2 is currently using), but it probably should be backported to all branches.

@Mergifyio backport 2.2.x 1.0.x

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [N/A] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [N/A] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [N/A] New feature has been added to the `versions.md` file (if applicable).
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: CI pass and failing tests are unrelated with the changes.
