### PR TITLE
[24095] Build: use GNUInstallDirs CMake module to create directory paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ endif()
 # Project                                                                     #
 ###############################################################################
 project(fastcdr VERSION 2.3.4 LANGUAGES CXX)
+include(GNUInstallDirs)
 
 set(PROJECT_NAME_STYLED "FastCDR")
 set(PROJECT_NAME_LARGE "Fast CDR")
@@ -90,20 +91,16 @@ option(APPEND_PROJECT_NAME_TO_INCLUDEDIR
   overriding this package from a merged catkin, ament, or colcon workspace."
   OFF)
 
-set(BIN_INSTALL_DIR bin/ CACHE PATH "Installation directory for binaries")
-set(_include_dir "include/")
+set(BIN_INSTALL_DIR "${CMAKE_INSTALL_BINDIR}" CACHE PATH "Installation directory for binaries")
+set(_include_dir "${CMAKE_INSTALL_INCLUDEDIR}")
 if(APPEND_PROJECT_NAME_TO_INCLUDEDIR)
   string(APPEND _include_dir "${PROJECT_NAME}/")
 endif()
 set(INCLUDE_INSTALL_DIR "${_include_dir}" CACHE PATH "Installation directory for C++ headers")
 unset(_include_dir)
-set(LIB_INSTALL_DIR lib${LIB_SUFFIX}/ CACHE PATH "Installation directory for libraries")
-set(DATA_INSTALL_DIR share/ CACHE PATH "Installation directory for data")
-if(WIN32)
-    set(DOC_DIR "doc")
-else()
-    set(DOC_DIR "${DATA_INSTALL_DIR}/doc")
-endif()
+set(LIB_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Installation directory for libraries")
+set(DATA_INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}" CACHE PATH "Installation directory for data")
+set(DOC_DIR "${CMAKE_INSTALL_DOCDIR}")
 set(DOC_INSTALL_DIR ${DOC_DIR} CACHE PATH "Installation directory for documentation")
 set(LICENSE_INSTALL_DIR ${DATA_INSTALL_DIR}/${PROJECT_NAME} CACHE PATH "Installation directory for licenses")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ endif()
 # Project                                                                     #
 ###############################################################################
 project(fastcdr VERSION 2.3.4 LANGUAGES CXX)
-include(GNUInstallDirs)
 
 set(PROJECT_NAME_STYLED "FastCDR")
 set(PROJECT_NAME_LARGE "Fast CDR")
@@ -91,6 +90,7 @@ option(APPEND_PROJECT_NAME_TO_INCLUDEDIR
   overriding this package from a merged catkin, ament, or colcon workspace."
   OFF)
 
+include(GNUInstallDirs)
 set(BIN_INSTALL_DIR "${CMAKE_INSTALL_BINDIR}" CACHE PATH "Installation directory for binaries")
 set(_include_dir "${CMAKE_INSTALL_INCLUDEDIR}")
 if(APPEND_PROJECT_NAME_TO_INCLUDEDIR)
@@ -100,8 +100,7 @@ set(INCLUDE_INSTALL_DIR "${_include_dir}" CACHE PATH "Installation directory for
 unset(_include_dir)
 set(LIB_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Installation directory for libraries")
 set(DATA_INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}" CACHE PATH "Installation directory for data")
-set(DOC_DIR "${CMAKE_INSTALL_DOCDIR}")
-set(DOC_INSTALL_DIR ${DOC_DIR} CACHE PATH "Installation directory for documentation")
+set(DOC_INSTALL_DIR ${CMAKE_INSTALL_DOCDIR} CACHE PATH "Installation directory for documentation")
 set(LICENSE_INSTALL_DIR ${DATA_INSTALL_DIR}/${PROJECT_NAME} CACHE PATH "Installation directory for licenses")
 
 ###############################################################################


### PR DESCRIPTION
## Description

Instead of defining manually certain install paths, use the standard (since 3.0) CMake module GNUInstallDirs to derive them. This is cross-platform and offers an automatic integration on distributions customizations (ie. when certain distribution system-wide define a specific place where to install stuff).

See also: https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html

The goal is to make the build more modern and software easy to deploy in any distribution.


## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: CI pass and failing tests are unrelated with the changes.
