### PR TITLE
Remove special GTest handling for ROS

### DIFF
--- a/cmake/common/find_or_add_gtest.cmake
+++ b/cmake/common/find_or_add_gtest.cmake
@@ -13,28 +13,6 @@
 # limitations under the License.
 
 macro(find_or_add_gtest)
-    # Check if building on an ament context, i.e. ROS 2
-    # Thanks to https://github.com/facontidavide/PlotJuggler/blob/main/CMakeLists.txt#L66
-    find_package(ament_cmake QUIET)
-
-    # This is a ROS 2 build
-    if(ament_cmake_FOUND)
-        # Find all GTest vendor required packages
-        find_package(ament_cmake REQUIRED)
-        find_package(gtest_vendor REQUIRED)
-        find_package(ament_cmake_gtest REQUIRED)
-
-        # Find GTest
-        ament_find_gtest()
-
-        # Add aliases for GTest libraries so we can use them as targets independently of the context
-        add_library(GTest::gtest ALIAS gtest)
-        add_library(GTest::gtest_main ALIAS gtest_main)
-        target_link_libraries(gtest_main gtest)
-
-    # This is a non-ROS 2 build
-    else()
-        # Find GTest normally
-        find_package(GTest CONFIG REQUIRED)
-    endif()
+    # Find GTest normally
+    find_package(GTest CONFIG REQUIRED)
 endmacro()

--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,8 +1,5 @@
 name: fastcdr
 type: cmake
 test-dependencies:
-    # Needed for test compilation in ROS 2 CI
-    - ament_cmake_gtest
-    - ament_cmake
     # Needed for test compilation in eProsima CI
     - googletest-distribution

--- a/package.xml
+++ b/package.xml
@@ -17,8 +17,7 @@
   <buildtool_depend>cmake</buildtool_depend>
   <doc_depend>doxygen</doc_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_cmake</test_depend>
+  <test_depend>libgtest-dev</test_depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
## Description

We're deprecating the `gtest_vendor` and `gmock_vendor` packages in ROS. You can now use the `libgtest-dev` rosdep key

https://github.com/ament/googletest/issues/37

I'd like this backported to 2.3.x for ROS 2 https://github.com/ros2/ros2/blob/29edd6c3ea3510ce77f5e41febe1148eaddf4b85/ros2.repos#L30-L33

## Contributor Checklist

- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: CI pass and failing tests are unrelated with the changes.
