### PR TITLE
Add pkg-config file

### DIFF
--- a/fastcdr.pc.in
+++ b/fastcdr.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=@includedir_for_pc_file@
+libdir=@libdir_for_pc_file@
+
+Name: fastcdr
+Description: C++ library for serialize using CDR serialization
+URL: https://github.com/eProsima/Fast-CDR
+Version: @PROJECT_VERSION@
+
+Cflags: -I${includedir} -DFASTCDR_DYN_LINK
+Cflags.private: -UFASTCDR_DYN_LINK -DFASTCDR_STATIC_LINK
+Libs: -L${libdir} -lfastcdr

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -195,3 +195,17 @@ install(FILES ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config.cmake
     DESTINATION ${INSTALL_DESTINATION_PATH}
     COMPONENT cmake
     )
+
+###############################################################################
+# Create pkg-config file
+###############################################################################
+cmake_path(APPEND includedir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+cmake_path(APPEND libdir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
+configure_file(
+    "${PROJECT_SOURCE_DIR}/fastcdr.pc.in"
+    "${PROJECT_BINARY_DIR}/fastcdr.pc"
+    @ONLY)
+install(FILES "${PROJECT_BINARY_DIR}/fastcdr.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+    COMPONENT pkgconfig
+    )


### PR DESCRIPTION
## Description
Currently, Fast-CDR only integrates with CMake, but there are many projects out there that are not built with CMake and thus cannot directly include Fast-CDR. pkg-config is often the least common denominator by many build systems.

Generate and install a pkg-config file to make Fast-CDR also usable by other build systems.

I checked the CMake config file for the FASTCDR_DYN_LINK and FASTCDR_STATIC_LINK flags and had to do a bit of a dance in pkg-config, but I hope `-DFASTCDR_DYN_LINK -UFASTCDR_DYN_LINK -DFASTCDR_STATIC_LINK` works satisfactorily.

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- N/A Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- N/A Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- N/A New feature has been added to the `versions.md` file (if applicable).
- N/A Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: CI pass and failing tests are unrelated with the changes.
