### PR TITLE
Reset optional members when deserializing a PLAIN_CDR stream.

### DIFF
--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -2751,6 +2751,51 @@ public:
     }
 
     /*!
+     * @brief Decodes an optional member of an external according to the encoding algorithm used.
+     * @param[out] member_value A reference of the variable where the optional member value will be stored.
+     * @return Reference to the eprosima::fastcdr::Cdr object.
+     * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
+     * position that exceeds the internal memory size.
+     */
+    template<class _T>
+    Cdr& deserialize_member(
+            optional<external<_T>>& member_value)
+    {
+        if (member_value.has_value() && member_value.value().is_locked())
+        {
+            throw exception::BadParamException("External member is locked");
+        }
+
+        if (EncodingAlgorithmFlag::PLAIN_CDR == current_encoding_)
+        {
+            Cdr::state current_state(*this);
+            MemberId member_id;
+            xcdr1_deserialize_member_header(member_id, current_state);
+            auto prev_offset = offset_;
+            member_value.reset(0 < current_state.member_size_);
+            if (0 < current_state.member_size_)
+            {
+                deserialize(member_value);
+            }
+            size_t member_size {current_state.member_size_};
+            size_t diff {offset_ - prev_offset};
+            if (member_size < diff)
+            {
+                throw exception::BadParamException(
+                          "Member size provided by member header is lower than real decoded member size");
+            }
+
+            // Skip unused bytes
+            offset_ += (member_size - diff);
+        }
+        else
+        {
+            deserialize(member_value);
+        }
+        return *this;
+    }
+
+    /*!
      * @brief Tells to the encoder a new type and its members starts to be encoded.
      * @param[in,out] current_state State of the encoder previous of calling this function.
      * @param[in] type_encoding The encoding algorithm used to encode the type and its members.

--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -720,7 +720,7 @@ public:
      * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
      * position that exceeds the internal memory size.
      */
-    template <size_t MAX_CHARS>
+    template<size_t MAX_CHARS>
     Cdr& serialize(
             const fixed_string<MAX_CHARS>& value)
     {
@@ -1787,7 +1787,7 @@ public:
      * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
      * position that exceeds the internal memory size.
      */
-    template <size_t MAX_CHARS>
+    template<size_t MAX_CHARS>
     Cdr& deserialize(
             fixed_string<MAX_CHARS>& value)
     {
@@ -2727,6 +2727,7 @@ public:
             MemberId member_id;
             xcdr1_deserialize_member_header(member_id, current_state);
             auto prev_offset = offset_;
+            member_value.reset(0 < current_state.member_size_);
             if (0 < current_state.member_size_)
             {
                 deserialize(member_value);

--- a/test/xcdr/external.cpp
+++ b/test/xcdr/external.cpp
@@ -435,7 +435,7 @@ using XCdrStreamValues =
                 1 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS>;
 
 
-class XCdrExternalTest : public ::testing::TestWithParam< std::tuple<EncodingAlgorithmFlag, Cdr::Endianness>>
+class XCdrExternalTest : public ::testing::TestWithParam<std::tuple<EncodingAlgorithmFlag, Cdr::Endianness>>
 {
 };
 
@@ -1154,6 +1154,150 @@ TEST_P(XCdrExternalTest, null_optional)
                 });
         ASSERT_FALSE(dopt_value.has_value());
         //}
+    }
+
+}
+
+/*!
+ * @test Test encoding of an empty optional field of an external.
+ * @code{.idl}
+ * struct ExternalClass
+ * {
+ *     string var_str;
+ * };
+ *
+ * struct NullOptional
+ * {
+ *     @optional @external
+ *     ExternalClass var_ext;
+ * };
+ * @endcode
+ */
+TEST(XCdrExternalTest, null_optional_on_initiated_value)
+{
+    //{ Defining expected XCDR streams
+    XCdrStreamValues expected_streams;
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x00  // ShortMemberHeader
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x01, 0x00, 0x00, 0x00  // ShortMemberHeader
+    };
+    //}
+
+    optional<external<ExternalClass>> opt_value;
+
+    for (uint8_t tested_stream {0}; tested_stream < 2; ++tested_stream)
+    {
+
+        //{ Calculate encoded size.
+        CdrSizeCalculator calculator(get_version_from_algorithm(EncodingAlgorithmFlag::PLAIN_CDR));
+        size_t current_alignment {0};
+        size_t calculated_size {calculator.begin_calculate_type_serialized_size(EncodingAlgorithmFlag::PLAIN_CDR,
+                                        current_alignment)};
+        calculated_size += calculator.calculate_member_serialized_size(MemberId(1), opt_value, current_alignment);
+        calculated_size += calculator.end_calculate_type_serialized_size(EncodingAlgorithmFlag::PLAIN_CDR,
+                        current_alignment);
+        calculated_size += 4; // Encapsulation
+        //}
+
+
+        {
+
+            //{ Prepare buffer
+            auto buffer =
+                    std::unique_ptr<char, void (*)(
+                void*)>{reinterpret_cast<char*>(calloc(expected_streams[tested_stream].size(), sizeof(char))), free};
+            FastBuffer fast_buffer(buffer.get(), expected_streams[tested_stream].size());
+            Cdr cdr(fast_buffer,
+                    0 == tested_stream ? Cdr::Endianness::BIG_ENDIANNESS : Cdr::Endianness::LITTLE_ENDIANNESS,
+                    get_version_from_algorithm(EncodingAlgorithmFlag::PLAIN_CDR));
+            //}
+
+            //{ Encode optional not present.
+            cdr.set_encoding_flag(EncodingAlgorithmFlag::PLAIN_CDR);
+            cdr.serialize_encapsulation();
+            Cdr::state enc_state(cdr);
+            cdr.begin_serialize_type(enc_state, EncodingAlgorithmFlag::PLAIN_CDR);
+            cdr.serialize_member(MemberId(1), opt_value);
+            cdr.end_serialize_type(enc_state);
+            cdr.set_dds_cdr_options({0, 0});
+            Cdr::state enc_state_end(cdr);
+            //}
+
+            //{ Test encoded content
+            ASSERT_EQ(cdr.get_serialized_data_length(), expected_streams[tested_stream].size());
+            ASSERT_EQ(cdr.get_serialized_data_length(), calculated_size);
+            ASSERT_EQ(0, memcmp(buffer.get(), expected_streams[tested_stream].data(),
+                    expected_streams[tested_stream].size()));
+            //}
+
+            //{ Decoding optional not present
+            optional<external<ExternalClass>> dopt_value {{new ExternalClass("CD")}};
+            cdr.reset();
+            cdr.read_encapsulation();
+            ASSERT_EQ(cdr.get_encoding_flag(), EncodingAlgorithmFlag::PLAIN_CDR);
+            ASSERT_EQ(cdr.endianness(),
+                    0 == tested_stream ? Cdr::Endianness::BIG_ENDIANNESS : Cdr::Endianness::LITTLE_ENDIANNESS);
+            cdr.deserialize_type(EncodingAlgorithmFlag::PLAIN_CDR, [&](Cdr& cdr_inner, const MemberId&)->bool
+                    {
+                        cdr_inner.deserialize_member(dopt_value);
+
+                        return false;
+                    });
+            ASSERT_FALSE(dopt_value.has_value());
+            //}
+        }
+
+        {
+            //{ Prepare buffer
+            auto buffer =
+                    std::unique_ptr<char, void (*)(
+                void*)>{reinterpret_cast<char*>(calloc(expected_streams[tested_stream].size(), sizeof(char))), free};
+            FastBuffer fast_buffer(buffer.get(), expected_streams[tested_stream].size());
+            Cdr cdr(fast_buffer,
+                    0 == tested_stream ? Cdr::Endianness::BIG_ENDIANNESS : Cdr::Endianness::LITTLE_ENDIANNESS,
+                    get_version_from_algorithm(EncodingAlgorithmFlag::PLAIN_CDR));
+            //}
+
+            //{ Encode optional not present.
+            cdr.set_encoding_flag(EncodingAlgorithmFlag::PLAIN_CDR);
+            cdr.serialize_encapsulation();
+            Cdr::state enc_state(cdr);
+            cdr.begin_serialize_type(enc_state, EncodingAlgorithmFlag::PLAIN_CDR);
+            cdr << MemberId(1) << opt_value;
+            cdr.end_serialize_type(enc_state);
+            cdr.set_dds_cdr_options({0, 0});
+            Cdr::state enc_state_end(cdr);
+            //}
+
+            //{ Test encoded content
+            ASSERT_EQ(cdr.get_serialized_data_length(), expected_streams[tested_stream].size());
+            ASSERT_EQ(cdr.get_serialized_data_length(), calculated_size);
+            ASSERT_EQ(0, memcmp(buffer.get(), expected_streams[tested_stream].data(),
+                    expected_streams[tested_stream].size()));
+            //}
+
+            //{ Decoding optional not present
+            optional<external<ExternalClass>> dopt_value{{ new ExternalClass("CD") }};
+            cdr.reset();
+            cdr.read_encapsulation();
+            ASSERT_EQ(cdr.get_encoding_flag(), EncodingAlgorithmFlag::PLAIN_CDR);
+            ASSERT_EQ(cdr.endianness(),
+                    0 == tested_stream ? Cdr::Endianness::BIG_ENDIANNESS : Cdr::Endianness::LITTLE_ENDIANNESS);
+            cdr.deserialize_type(EncodingAlgorithmFlag::PLAIN_CDR, [&](Cdr& cdr_inner, const MemberId&)->bool
+                    {
+                        cdr_inner >> dopt_value;
+
+                        return false;
+                    });
+            ASSERT_FALSE(dopt_value.has_value());
+            //}
+        }
     }
 
 }

--- a/test/xcdr/optional.cpp
+++ b/test/xcdr/optional.cpp
@@ -31,7 +31,7 @@ using XCdrStreamValues =
                 1 + EncodingAlgorithmFlag::PL_CDR2 + Cdr::Endianness::LITTLE_ENDIANNESS>;
 
 
-class XCdrOptionalTest : public ::testing::TestWithParam< std::tuple<EncodingAlgorithmFlag, Cdr::Endianness>>
+class XCdrOptionalTest : public ::testing::TestWithParam<std::tuple<EncodingAlgorithmFlag, Cdr::Endianness>>
 {
 };
 
@@ -7910,6 +7910,143 @@ TEST_P(XCdrOptionalTest, two_inner_short_optional)
         Cdr::state dec_state_end(cdr);
         ASSERT_EQ(enc_state_end, dec_state_end);
         //}
+    }
+}
+
+/*!
+ * @test Test encoding of an empty optional field of octet type
+ * @code{.idl}
+ * struct NullOptional
+ * {
+ *     @optional
+ *     octet var_octet;
+ * };
+ * @endcode
+ */
+TEST(XCdrOptionalTest, plaincdr_regression_test)
+{
+    //{ Defining expected XCDR streams
+    XCdrStreamValues expected_streams;
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::BIG_ENDIANNESS] =
+    {
+        0x00, 0x00, 0x00, 0x00, // Encapsulation
+        0x00, 0x01, 0x00, 0x00  // ShortMemberHeader
+    };
+    expected_streams[0 + EncodingAlgorithmFlag::PLAIN_CDR + Cdr::Endianness::LITTLE_ENDIANNESS] =
+    {
+        0x00, 0x01, 0x00, 0x00, // Encapsulation
+        0x01, 0x00, 0x00, 0x00  // ShortMemberHeader
+    };
+    //}
+
+    optional<uint8_t> opt_value;
+
+    for (uint8_t tested_stream {0}; tested_stream < 2; ++tested_stream)
+    {
+
+        //{ Calculate encoded size.
+        CdrSizeCalculator calculator(get_version_from_algorithm(EncodingAlgorithmFlag::PLAIN_CDR));
+        size_t current_alignment {0};
+        size_t calculated_size {calculator.begin_calculate_type_serialized_size(EncodingAlgorithmFlag::PLAIN_CDR,
+                                        current_alignment)};
+        calculated_size += calculator.calculate_member_serialized_size(MemberId(1), opt_value, current_alignment);
+        calculated_size += calculator.end_calculate_type_serialized_size(EncodingAlgorithmFlag::PLAIN_CDR,
+                        current_alignment);
+        calculated_size += 4; // Encapsulation
+        //}
+
+        {
+
+            //{ Prepare buffer
+            auto buffer =
+                    std::unique_ptr<char, void (*)(
+                void*)>{reinterpret_cast<char*>(calloc(expected_streams[tested_stream].size(), sizeof(char))), free};
+            FastBuffer fast_buffer(buffer.get(), expected_streams[tested_stream].size());
+            Cdr cdr(fast_buffer,
+                    0 == tested_stream ? Cdr::Endianness::BIG_ENDIANNESS : Cdr::Endianness::LITTLE_ENDIANNESS,
+                    get_version_from_algorithm(EncodingAlgorithmFlag::PLAIN_CDR));
+            //}
+
+            //{ Encode optional not present.
+            cdr.set_encoding_flag(EncodingAlgorithmFlag::PLAIN_CDR);
+            cdr.serialize_encapsulation();
+            Cdr::state enc_state(cdr);
+            cdr.begin_serialize_type(enc_state, EncodingAlgorithmFlag::PLAIN_CDR);
+            cdr.serialize_member(MemberId(1), opt_value);
+            cdr.end_serialize_type(enc_state);
+            cdr.set_dds_cdr_options({0, 0});
+            Cdr::state enc_state_end(cdr);
+            //}
+
+            //{ Test encoded content
+            ASSERT_EQ(cdr.get_serialized_data_length(), expected_streams[tested_stream].size());
+            ASSERT_EQ(cdr.get_serialized_data_length(), calculated_size);
+            ASSERT_EQ(0, memcmp(buffer.get(), expected_streams[tested_stream].data(),
+                    expected_streams[tested_stream].size()));
+            //}
+
+            //{ Decoding optional not present
+            optional<uint8_t> dopt_value {3};
+            cdr.reset();
+            cdr.read_encapsulation();
+            ASSERT_EQ(cdr.get_encoding_flag(), EncodingAlgorithmFlag::PLAIN_CDR);
+            ASSERT_EQ(cdr.endianness(),
+                    0 == tested_stream ? Cdr::Endianness::BIG_ENDIANNESS : Cdr::Endianness::LITTLE_ENDIANNESS);
+            cdr.deserialize_type(EncodingAlgorithmFlag::PLAIN_CDR, [&](Cdr& cdr_inner, const MemberId&)->bool
+                    {
+                        cdr_inner.deserialize_member(dopt_value);
+
+                        return false;
+                    });
+            ASSERT_FALSE(dopt_value.has_value());
+            //}
+        }
+
+        {
+            //{ Prepare buffer
+            auto buffer =
+                    std::unique_ptr<char, void (*)(
+                void*)>{reinterpret_cast<char*>(calloc(expected_streams[tested_stream].size(), sizeof(char))), free};
+            FastBuffer fast_buffer(buffer.get(), expected_streams[tested_stream].size());
+            Cdr cdr(fast_buffer,
+                    0 == tested_stream ? Cdr::Endianness::BIG_ENDIANNESS : Cdr::Endianness::LITTLE_ENDIANNESS,
+                    get_version_from_algorithm(EncodingAlgorithmFlag::PLAIN_CDR));
+            //}
+
+            //{ Encode optional not present.
+            cdr.set_encoding_flag(EncodingAlgorithmFlag::PLAIN_CDR);
+            cdr.serialize_encapsulation();
+            Cdr::state enc_state(cdr);
+            cdr.begin_serialize_type(enc_state, EncodingAlgorithmFlag::PLAIN_CDR);
+            cdr << MemberId(1) << opt_value;
+            cdr.end_serialize_type(enc_state);
+            cdr.set_dds_cdr_options({0, 0});
+            Cdr::state enc_state_end(cdr);
+            //}
+
+            //{ Test encoded content
+            ASSERT_EQ(cdr.get_serialized_data_length(), expected_streams[tested_stream].size());
+            ASSERT_EQ(cdr.get_serialized_data_length(), calculated_size);
+            ASSERT_EQ(0, memcmp(buffer.get(), expected_streams[tested_stream].data(),
+                    expected_streams[tested_stream].size()));
+            //}
+
+            //{ Decoding optional not present
+            optional<uint8_t> dopt_value {3};
+            cdr.reset();
+            cdr.read_encapsulation();
+            ASSERT_EQ(cdr.get_encoding_flag(), EncodingAlgorithmFlag::PLAIN_CDR);
+            ASSERT_EQ(cdr.endianness(),
+                    0 == tested_stream ? Cdr::Endianness::BIG_ENDIANNESS : Cdr::Endianness::LITTLE_ENDIANNESS);
+            cdr.deserialize_type(EncodingAlgorithmFlag::PLAIN_CDR, [&](Cdr& cdr_inner, const MemberId&)->bool
+                    {
+                        cdr_inner >> dopt_value;
+
+                        return false;
+                    });
+            ASSERT_FALSE(dopt_value.has_value());
+            //}
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Reset optional members when deserializing a PLAIN_CDR stream.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.2.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: CI pass and failing tests are unrelated with the changes.
