### PR TITLE
[24365] Fix UB in serialization methods

### DIFF
--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -2973,7 +2973,7 @@ private:
             const std::array<_T, _Size>* array_t,
             size_t num_elements)
     {
-        if (num_elements == 0)
+        if (num_elements == 0 || array_t == nullptr)
         {
             return *this;
         }
@@ -2992,6 +2992,10 @@ private:
             std::array<_T, _Size>* array_t,
             size_t num_elements)
     {
+        if (num_elements == 0 || array_t == nullptr)
+        {
+            return *this;
+        }
         return deserialize_array(array_t->data(), num_elements * array_t->size());
     }
 
@@ -3009,6 +3013,10 @@ private:
             size_t num_elements,
             Endianness endianness)
     {
+        if (num_elements == 0 || array_t == nullptr)
+        {
+            return *this;
+        }
         return deserialize_array(array_t->data(), num_elements * array_t->size(), endianness);
     }
 

--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -720,7 +720,7 @@ public:
      * @exception exception::NotEnoughMemoryException This exception is thrown when trying to encode into a buffer
      * position that exceeds the internal memory size.
      */
-    template <size_t MAX_CHARS>
+    template<size_t MAX_CHARS>
     Cdr& serialize(
             const fixed_string<MAX_CHARS>& value)
     {
@@ -1787,7 +1787,7 @@ public:
      * @exception exception::NotEnoughMemoryException This exception is thrown when trying to decode from a buffer
      * position that exceeds the internal memory size.
      */
-    template <size_t MAX_CHARS>
+    template<size_t MAX_CHARS>
     Cdr& deserialize(
             fixed_string<MAX_CHARS>& value)
     {

--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -2973,6 +2973,10 @@ private:
             const std::array<_T, _Size>* array_t,
             size_t num_elements)
     {
+        if (num_elements == 0)
+        {
+            return *this;
+        }
         return serialize_array(array_t->data(), num_elements * array_t->size());
     }
 

--- a/include/fastcdr/CdrSizeCalculator.hpp
+++ b/include/fastcdr/CdrSizeCalculator.hpp
@@ -1065,7 +1065,7 @@ public:
             size_t num_elements,
             size_t& current_alignment)
     {
-        if (0 == num_elements)
+        if (num_elements == 0 || data == nullptr)
         {
             return 0;
         }

--- a/include/fastcdr/CdrSizeCalculator.hpp
+++ b/include/fastcdr/CdrSizeCalculator.hpp
@@ -1065,7 +1065,11 @@ public:
             size_t num_elements,
             size_t& current_alignment)
     {
-        return calculate_array_serialized_size(data->data(), num_elements * data->size(), current_alignment);
+        if (0 == num_elements)
+        {
+            return 0;
+        }
+        return calculate_array_serialized_size(data->data(), num_elements * _N, current_alignment);
     }
 
     /*!

--- a/include/fastcdr/CdrSizeCalculator.hpp
+++ b/include/fastcdr/CdrSizeCalculator.hpp
@@ -480,7 +480,7 @@ public:
      * @param[inout] current_alignment Current alignment in the encoding.
      * @return Encoded size of the instance.
      */
-    template <size_t MAX_CHARS>
+    template<size_t MAX_CHARS>
     size_t calculate_serialized_size(
             const fixed_string<MAX_CHARS>& data,
             size_t& current_alignment)

--- a/include/fastcdr/FastCdr.h
+++ b/include/fastcdr/FastCdr.h
@@ -2047,6 +2047,10 @@ private:
             const std::array<_T, _Size>* array_t,
             size_t num_elements)
     {
+        if (num_elements == 0 || array_t == nullptr)
+        {
+            return *this;
+        }
         return serialize_array(array_t->data(), num_elements * array_t->size());
     }
 
@@ -2062,6 +2066,10 @@ private:
             std::array<_T, _Size>* array_t,
             size_t num_elements)
     {
+        if (num_elements == 0 || array_t == nullptr)
+        {
+            return *this;
+        }
         return deserialize_array(array_t->data(), num_elements * array_t->size());
     }
 

--- a/include/fastcdr/FastCdr.h
+++ b/include/fastcdr/FastCdr.h
@@ -655,7 +655,8 @@ public:
             return *this;
         }
 
-        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        throw exception::NotEnoughMemoryException(
+                  exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
     /*!
@@ -702,7 +703,8 @@ public:
             return *this;
         }
 
-        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        throw exception::NotEnoughMemoryException(
+                  exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
     /*!
@@ -736,7 +738,8 @@ public:
             return *this;
         }
 
-        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        throw exception::NotEnoughMemoryException(
+                  exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
     /*!
@@ -783,7 +786,8 @@ public:
             return *this;
         }
 
-        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        throw exception::NotEnoughMemoryException(
+                  exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
     /*!
@@ -804,7 +808,8 @@ public:
             return *this;
         }
 
-        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        throw exception::NotEnoughMemoryException(
+                  exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
     /*!
@@ -825,7 +830,8 @@ public:
             return *this;
         }
 
-        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        throw exception::NotEnoughMemoryException(
+                  exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
     /*!
@@ -850,7 +856,8 @@ public:
             return *this;
         }
 
-        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        throw exception::NotEnoughMemoryException(
+                  exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
     /*!
@@ -1306,7 +1313,8 @@ public:
             return *this;
         }
 
-        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        throw exception::NotEnoughMemoryException(
+                  exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
     /*!
@@ -1353,7 +1361,8 @@ public:
             return *this;
         }
 
-        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        throw exception::NotEnoughMemoryException(
+                  exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
     /*!
@@ -1387,7 +1396,8 @@ public:
             return *this;
         }
 
-        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        throw exception::NotEnoughMemoryException(
+                  exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
     /*!
@@ -1437,7 +1447,8 @@ public:
             return *this;
         }
 
-        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        throw exception::NotEnoughMemoryException(
+                  exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
     /*!
@@ -1458,7 +1469,8 @@ public:
             return *this;
         }
 
-        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        throw exception::NotEnoughMemoryException(
+                  exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
     /*!
@@ -1479,7 +1491,8 @@ public:
             return *this;
         }
 
-        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        throw exception::NotEnoughMemoryException(
+                  exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
     /*!
@@ -1503,7 +1516,8 @@ public:
             return *this;
         }
 
-        throw exception::NotEnoughMemoryException(exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+        throw exception::NotEnoughMemoryException(
+                  exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
     }
 
     /*!


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
This PR fixes:
- UB error `CdrSizeCalculator.hpp:1068:87: member call on null pointer of type 'const struct array'` caused by an access to `data->data()` when size is 0.
- UB error `Cdr.h:2976:77: runtime error: member call on null pointer of type 'const struct array'` caused by an access to `data->data()` when size is 0.

## Related PRs
- https://github.com/eProsima/Fast-DDS/pull/6386

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.2.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: CI pass and failing tests are unrelated with the changes.
