### PR TITLE
[24603] Add opt-in strict bool normalization

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -68,10 +68,13 @@ jobs:
       matrix:
         cmake-build-type:
           - 'RelWithDebInfo'
+        strict-bool:
+          - false
+          - true
 
     steps:
     - name: Add ci-pending label if PR
-      if: ${{ github.event_name == 'pull_request' && inputs.add-label == true}}
+      if: ${{ github.event_name == 'pull_request' && inputs.add-label == true && matrix.strict-bool == false }}
       uses: eProsima/eProsima-CI/external/add_labels@v0
       with:
         labels: ci-pending
@@ -122,7 +125,7 @@ jobs:
         colcon_meta_file: ${{ github.workspace }}/src/fastcdr/.github/workflows/config/build.meta
         colcon_build_args: ${{ inputs.colcon-args }}
         colcon_build_args_default: --event-handlers=console_direct+
-        cmake_args: ${{ inputs.cmake-args }}
+        cmake_args: ${{ inputs.cmake-args }} ${{ matrix.strict-bool == true && '-DSTRICT_BOOL=ON' || '' }}
         cmake_args_default: ${{ env.colcon-build-default-cmake-args }} ${{ env.toolset }}
         cmake_build_type: ${{ matrix.cmake-build-type }}
         workspace: ${{ github.workspace }}
@@ -137,7 +140,7 @@ jobs:
         ctest_args: ${{ inputs.ctest-args }}
         packages_names: fastcdr
         workspace: ${{ github.workspace }}
-        test_report_artifact: ${{ inputs.label }}
+        test_report_artifact: ${{ inputs.label }}${{ matrix.strict-bool == true && '-strict-bool' || '' }}
 
     - name: Fast CDR Test summary
       uses: eProsima/eProsima-CI/multiplatform/junit_summary@v0
@@ -153,5 +156,5 @@ jobs:
       if: always()
       uses: eProsima/eProsima-CI/external/upload-artifact@v0
       with:
-        name: test-results-${{ inputs.label }}
+        name: test-results-${{ inputs.label }}${{ matrix.strict-bool == true && '-strict-bool' || '' }}
         path: log/latest_test/fastcdr

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,11 @@ endif()
 option(BUILD_SHARED_LIBS "Create shared libraries by default" ON)
 
 ###############################################################################
+# Strict bool
+###############################################################################
+option(STRICT_BOOL "Enforce bool values to 0/1 during serialization" OFF)
+
+###############################################################################
 # Test system configuration
 ###############################################################################
 include(${PROJECT_SOURCE_DIR}/cmake/common/check_configuration.cmake)

--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -3008,6 +3008,16 @@ private:
             size_t& num_elements);
 
     /*!
+     * @brief Serializes the canonical @c uint8_t representation of @p bool_t.
+     *
+     * When @c FASTCDR_STRICT_BOOL is defined the serialized value is guaranteed to be exactly @c 0 or @c 1.
+     *
+     * @param[in] bool_t The boolean value to serialize.
+     */
+    Cdr_DllAPI void serialize_bool(
+            bool bool_t);
+
+    /*!
      * @brief This function template detects the content type of the STD container array and serializes the array.
      * @param array_t The array that will be serialized in the buffer.
      * @param num_elements Number of the elements in the array.

--- a/include/fastcdr/FastCdr.h
+++ b/include/fastcdr/FastCdr.h
@@ -2041,6 +2041,16 @@ private:
     FastCdr& deserialize_bool_sequence(
             std::vector<bool>& vector_t);
 
+    /*!
+     * @brief Serializes the canonical @c uint8_t representation of @p bool_t.
+     *
+     * When @c FASTCDR_STRICT_BOOL is defined the serialized value is guaranteed to be exactly @c 0 or @c 1.
+     *
+     * @param[in] bool_t The boolean value to serialize.
+     */
+    void serialize_bool(
+            bool bool_t);
+
     FastCdr& deserialize_string_sequence(
             std::string*& sequence_t,
             size_t& num_elements);

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -32,6 +32,7 @@ set(${PROJECT_NAME}_source_files
     exceptions/Exception.cpp
     exceptions/LockedExternalAccessException.cpp
     exceptions/NotEnoughMemoryException.cpp
+    helpers/memory_helpers.cpp
     FastCdr.rc
     )
 
@@ -57,6 +58,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 target_compile_definitions(${PROJECT_NAME}
     PRIVATE
     ${PROJECT_NAME_UPPER}_SOURCE
+    $<$<BOOL:${STRICT_BOOL}>:${PROJECT_NAME_UPPER}_STRICT_BOOL>
     INTERFACE
     $<$<BOOL:${WIN32}>:${PROJECT_NAME_UPPER}_NO_LIB>
     PUBLIC

--- a/src/cpp/Cdr.cpp
+++ b/src/cpp/Cdr.cpp
@@ -16,6 +16,7 @@
 #include <limits>
 
 #include <fastcdr/Cdr.h>
+#include "helpers/memory_helpers.hpp"
 
 namespace eprosima {
 namespace fastcdr {
@@ -821,14 +822,7 @@ Cdr& Cdr::serialize(
         // Save last datasize.
         last_data_size_ = sizeof(uint8_t);
 
-        if (bool_t)
-        {
-            offset_++ << static_cast<uint8_t>(1);
-        }
-        else
-        {
-            offset_++ << static_cast<uint8_t>(0);
-        }
+        serialize_bool(bool_t);
 
         return *this;
     }
@@ -929,13 +923,7 @@ Cdr& Cdr::serialize_array(
 
         for (size_t count = 0; count < num_elements; ++count)
         {
-            uint8_t value = 0;
-
-            if (bool_t[count])
-            {
-                value = 1;
-            }
-            offset_++ << value;
+            serialize_bool(bool_t[count]);
         }
 
         return *this;
@@ -2179,6 +2167,16 @@ Cdr& Cdr::operator <<(
     return *this;
 }
 
+inline void Cdr::serialize_bool(
+        bool bool_t)
+{
+#if FASTCDR_STRICT_BOOL
+    offset_++ <<  static_cast<uint8_t>(normalize_bool(bool_t));
+#else
+    offset_++ << (bool_t ? static_cast<uint8_t>(1) : static_cast<uint8_t>(0));
+#endif // if FASTCDR_STRICT_BOOL
+}
+
 Cdr& Cdr::serialize_bool_array(
         const std::vector<bool>& vector_t)
 {
@@ -2193,14 +2191,7 @@ Cdr& Cdr::serialize_bool_array(
 
         for (size_t count = 0; count < vector_t.size(); ++count)
         {
-            uint8_t value = 0;
-            std::vector<bool>::const_reference ref = vector_t[count];
-
-            if (ref)
-            {
-                value = 1;
-            }
-            offset_++ << value;
+            serialize_bool(vector_t[count]);
         }
     }
     else
@@ -2233,14 +2224,7 @@ Cdr& Cdr::serialize_bool_sequence(
 
         for (size_t count = 0; count < vector_t.size(); ++count)
         {
-            uint8_t value = 0;
-            std::vector<bool>::const_reference ref = vector_t[count];
-
-            if (ref)
-            {
-                value = 1;
-            }
-            offset_++ << value;
+            serialize_bool(vector_t[count]);
         }
     }
     else

--- a/src/cpp/FastCdr.cpp
+++ b/src/cpp/FastCdr.cpp
@@ -15,6 +15,7 @@
 #include <fastcdr/FastCdr.h>
 #include <fastcdr/exceptions/BadParamException.h>
 #include <string.h>
+#include "helpers/memory_helpers.hpp"
 
 using namespace eprosima::fastcdr;
 using namespace ::exception;
@@ -90,15 +91,9 @@ bool FastCdr::resize(
 FastCdr& FastCdr::serialize(
         const bool bool_t)
 {
-    uint8_t value = 0;
-
     if (((last_position_ - current_position_) >= sizeof(uint8_t)) || resize(sizeof(uint8_t)))
     {
-        if (bool_t)
-        {
-            value = 1;
-        }
-        current_position_++ << value;
+        serialize_bool(bool_t);
 
         return *this;
     }
@@ -190,13 +185,7 @@ FastCdr& FastCdr::serialize_array(
     {
         for (size_t count = 0; count < num_elements; ++count)
         {
-            uint8_t value = 0;
-
-            if (bool_t[count])
-            {
-                value = 1;
-            }
-            current_position_++ << value;
+            serialize_bool(bool_t[count]);
         }
 
         return *this;
@@ -691,6 +680,16 @@ FastCdr& FastCdr::deserialize_array(
     throw NotEnoughMemoryException(NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
 }
 
+inline void FastCdr::serialize_bool(
+        bool bool_t)
+{
+#if FASTCDR_STRICT_BOOL
+    current_position_++ << static_cast<uint8_t>(normalize_bool(bool_t));
+#else
+    current_position_++ << (bool_t ? static_cast<uint8_t>(1) : static_cast<uint8_t>(0));
+#endif // if FASTCDR_STRICT_BOOL
+}
+
 FastCdr& FastCdr::serialize_bool_sequence(
         const std::vector<bool>& vector_t)
 {
@@ -704,14 +703,7 @@ FastCdr& FastCdr::serialize_bool_sequence(
     {
         for (size_t count = 0; count < vector_t.size(); ++count)
         {
-            uint8_t value = 0;
-            std::vector<bool>::const_reference ref = vector_t[count];
-
-            if (ref)
-            {
-                value = 1;
-            }
-            current_position_++ << value;
+            serialize_bool(vector_t[count]);
         }
     }
     else

--- a/src/cpp/helpers/memory_helpers.cpp
+++ b/src/cpp/helpers/memory_helpers.cpp
@@ -1,0 +1,25 @@
+// Copyright 2026 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "memory_helpers.hpp"
+
+namespace {
+void const volatile* volatile global_force_escape_pointer;
+} // namespace
+
+void eprosima::fastcdr::internal::use_char_pointer(
+        char const volatile *const v)
+{
+    global_force_escape_pointer = reinterpret_cast<void const volatile*>(v);
+}

--- a/src/cpp/helpers/memory_helpers.hpp
+++ b/src/cpp/helpers/memory_helpers.hpp
@@ -1,0 +1,160 @@
+// Copyright 2026 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _SRC_CPP_HELPERS_MEMORYHELPERS_HPP_
+#define _SRC_CPP_HELPERS_MEMORYHELPERS_HPP_
+
+#include <atomic>
+#include <type_traits>
+#include <utility>
+#include <cstring>
+
+namespace eprosima {
+namespace fastcdr {
+
+namespace internal {
+void use_char_pointer(
+        char const volatile *const v);
+} // namespace internal
+
+#if (!defined(__GNUC__) && !defined(__clang__)) || defined(__pnacl__) || \
+    defined(__EMSCRIPTEN__)
+#define HAS_NO_INLINE_ASSEMBLY
+#endif // if (!defined(__GNUC__) && !defined(__clang__)) || defined(__pnacl__) || defined(__EMSCRIPTEN__)
+
+inline void clobber_memory()
+{
+    std::atomic_signal_fence(std::memory_order_acq_rel);
+}
+
+#ifndef HAS_NO_INLINE_ASSEMBLY
+#if !defined(__GNUC__) || defined(__llvm__) || defined(__INTEL_COMPILER)
+template<class Tp>
+inline void do_not_optimize(
+        Tp& value)
+{
+#if defined(__clang__)
+    asm volatile ("" : "+r,m" (value) : : "memory");
+#else
+    asm volatile ("" : "+m,r" (value) : : "memory");
+#endif // if defined(__clang__)
+}
+
+template<class Tp>
+inline void do_not_optimize(
+        Tp&& value)
+{
+#if defined(__clang__)
+    asm volatile ("" : "+r,m" (value) : : "memory");
+#else
+    asm volatile ("" : "+m,r" (value) : : "memory");
+#endif // if defined(__clang__)
+}
+
+#elif (__GNUC__ >= 5)
+template<class Tp>
+inline typename std::enable_if<std::is_trivially_copyable<Tp>::value&&
+        (sizeof(Tp) <= sizeof(Tp*))>::type
+do_not_optimize(
+        Tp& value)
+{
+    asm volatile ("" : "+m,r" (value) : : "memory");
+}
+
+template<class Tp>
+inline typename std::enable_if<!std::is_trivially_copyable<Tp>::value ||
+        (sizeof(Tp) > sizeof(Tp*))>::type
+do_not_optimize(
+        Tp& value)
+{
+    asm volatile ("" : "+m" (value) : : "memory");
+}
+
+template<class Tp>
+inline typename std::enable_if<std::is_trivially_copyable<Tp>::value&&
+        (sizeof(Tp) <= sizeof(Tp*))>::type
+do_not_optimize(
+        Tp&& value)
+{
+    asm volatile ("" : "+m,r" (value) : : "memory");
+}
+
+template<class Tp>
+inline typename std::enable_if<!std::is_trivially_copyable<Tp>::value ||
+        (sizeof(Tp) > sizeof(Tp*))>::type
+do_not_optimize(
+        Tp&& value)
+{
+    asm volatile ("" : "+m" (value) : : "memory");
+}
+
+#endif // if !defined(__GNUC__) || defined(__llvm__) || defined(__INTEL_COMPILER)
+
+#elif defined(_MSC_VER)
+template<class Tp>
+inline void do_not_optimize(
+        Tp& value)
+{
+    internal::use_char_pointer(&reinterpret_cast<char const volatile&>(value));
+    clobber_memory();
+}
+
+template<class Tp>
+inline void do_not_optimize(
+        Tp&& value)
+{
+    internal::use_char_pointer(&reinterpret_cast<char const volatile&>(value));
+    clobber_memory();
+}
+
+#else
+template<class Tp>
+inline void do_not_optimize(
+        Tp&& value)
+{
+    internal::use_char_pointer(&reinterpret_cast<char const volatile&>(value));
+}
+
+#endif // ifndef HAS_NO_INLINE_ASSEMBLY
+
+/*!
+ * @brief Normalizes a boolean value to a canonical 0 or 1 representation.
+ *
+ * In release builds, the compiler may optimize away explicit normalization
+ * of bool values (e.g. `if (b) { write 1; } else { write 0; }`), resulting
+ * in the raw underlying byte being written directly to the serialization
+ * buffer. If that byte contains garbage (e.g. from an uninitialized or
+ * improperly assigned field), a non-canonical value ends up on the wire,
+ * causing deserialization failures on the receiving side.
+ *
+ * This function forces normalization by reading the bool's raw byte via
+ * @c memcpy and passing it through a compiler barrier (@c do_not_optimize)
+ * preventing the optimization from eliding the check.
+ *
+ * @param b The boolean value to normalize.
+ * @return @c true if the underlying byte is non-zero, @c false otherwise.
+ */
+inline bool normalize_bool(
+        bool b) noexcept
+{
+    uint8_t raw;
+    std::memcpy(&raw, &b, 1);
+    do_not_optimize(raw);
+    return static_cast<bool>(raw);
+}
+
+} // namespace fastcdr
+} // namespace eprosima
+
+#endif // _SRC_CPP_HELPERS_MEMORYHELPERS_HPP_

--- a/test/cdr/BoolStrictTest.cpp
+++ b/test/cdr/BoolStrictTest.cpp
@@ -1,0 +1,362 @@
+// Copyright 2026 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstddef>
+#include <fastcdr/Cdr.h>
+#include <fastcdr/FastCdr.h>
+
+#include <gtest/gtest.h>
+
+using namespace eprosima::fastcdr;
+
+#define BUFFER_LENGTH 2000
+#define N_ARR_ELEMENTS 5
+
+static const bool expected_bool_value{true};
+static const bool expected_array_value[N_ARR_ELEMENTS]{true, false, true, false, true};
+static const std::array<bool, N_ARR_ELEMENTS> expected_std_array_value{true, false, true, false, true};
+static const std::vector<bool> expected_std_vector_value{true, false, true, false, true};
+
+template<typename T>
+void EXPECT_ARRAY_EQ(
+        T * array1,
+        const T * array2,
+        size_t size)
+{
+    for (size_t count = 0; count < size; ++count)
+    {
+        EXPECT_EQ(array1[count], array2[count]);
+    }
+}
+
+bool make_bool_truthy(
+        uint8_t raw = 0xFF)
+{
+    bool bool_t{};
+    std::memcpy(&bool_t, &raw, 1);
+    return bool_t;
+}
+
+void make_bool_array_truthy(
+        bool * bool_array,
+        size_t len,
+        uint8_t raw = 0xFF)
+{
+    for (size_t i = 0; i < len; i += 2)
+    {
+        std::memcpy(&bool_array[i], &raw, 1);
+    }
+}
+
+std::array<bool, N_ARR_ELEMENTS> make_bool_std_array_truthy(
+        uint8_t raw = 0xFF)
+{
+    std::array<bool, N_ARR_ELEMENTS> bool_array{};
+    make_bool_array_truthy(bool_array.data(), bool_array.size(), raw);
+
+    return bool_array;
+}
+
+std::vector<bool> make_bool_std_vector_truthy(
+        uint8_t raw = 0xFF)
+{
+    std::vector<bool> bool_vector(N_ARR_ELEMENTS, false);
+    bool value{false};
+    std::memcpy(&value, &raw, 1);
+    for (size_t i = 0; i < N_ARR_ELEMENTS; i += 2)
+    {
+        bool_vector[i] = value;
+    }
+    return bool_vector;
+}
+
+template<typename T>
+static void check_good_case(
+        const T& input_value,
+        const T& expected_value)
+{
+    char buffer[BUFFER_LENGTH];
+    {
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_ser(cdrbuffer,
+                eprosima::fastcdr::Cdr::Endianness::LITTLE_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_ser << input_value);
+    }
+
+    {
+        T output_value{};
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_des(cdrbuffer,
+                eprosima::fastcdr::Cdr::Endianness::LITTLE_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_des >> output_value);
+        EXPECT_EQ(output_value, expected_value);
+    }
+
+    {
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_ser(cdrbuffer, eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_ser << input_value);
+    }
+
+    {
+        T output_value{};
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_des(cdrbuffer, eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_des >> output_value);
+        EXPECT_EQ(output_value, expected_value);
+    }
+}
+
+template<typename T, size_t N = N_ARR_ELEMENTS>
+static void check_good_case_array(
+        const T& input_value,
+        const T& expected_value)
+{
+    char buffer[BUFFER_LENGTH];
+    {
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_ser(cdrbuffer,
+                eprosima::fastcdr::Cdr::Endianness::LITTLE_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_ser.serialize_array(input_value, N));
+    }
+
+    {
+        T output_value{};
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_des(cdrbuffer,
+                eprosima::fastcdr::Cdr::Endianness::LITTLE_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_des.deserialize_array(output_value, N));
+        EXPECT_ARRAY_EQ(output_value, expected_value, N);
+    }
+
+    {
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_ser(cdrbuffer, eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_ser.serialize_array(input_value, N));
+    }
+
+    {
+        T output_value{};
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_des(cdrbuffer, eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_des.deserialize_array(output_value, N));
+        EXPECT_ARRAY_EQ(output_value, expected_value, N);
+    }
+}
+
+TEST(CDRBoolStrictTests, BooleanTruthy)
+{
+    const bool bool_t{make_bool_truthy()};
+    check_good_case(bool_t, expected_bool_value);
+}
+
+TEST(CDRBoolStrictTests, STDArrayBooleanTruthy)
+{
+    std::array<bool, N_ARR_ELEMENTS> bool_array_t{make_bool_std_array_truthy()};
+    check_good_case(bool_array_t, expected_std_array_value);
+}
+
+TEST(CDRBoolStrictTests, ArrayBooleanTruthy)
+{
+    bool bool_array_t[N_ARR_ELEMENTS]{};
+    make_bool_array_truthy(bool_array_t, N_ARR_ELEMENTS);
+    check_good_case_array(bool_array_t, expected_array_value);
+
+    char buffer[BUFFER_LENGTH];
+    {
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_ser(cdrbuffer,
+                eprosima::fastcdr::Cdr::Endianness::LITTLE_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_ser.serialize_array(bool_array_t, N_ARR_ELEMENTS));
+    }
+
+    {
+        bool output_value[N_ARR_ELEMENTS]{};
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_des(cdrbuffer,
+                eprosima::fastcdr::Cdr::Endianness::LITTLE_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_des.deserialize_array(output_value, N_ARR_ELEMENTS));
+        EXPECT_ARRAY_EQ(output_value, expected_array_value, N_ARR_ELEMENTS);
+    }
+
+    {
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_ser(cdrbuffer, eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_ser.serialize_array(bool_array_t, N_ARR_ELEMENTS));
+    }
+
+    {
+        bool output_value[N_ARR_ELEMENTS]{};
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_des(cdrbuffer, eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_des.deserialize_array(output_value, N_ARR_ELEMENTS));
+        EXPECT_ARRAY_EQ(output_value, expected_array_value, N_ARR_ELEMENTS);
+    }
+}
+
+TEST(CDRBoolStrictTests, STDVectorBooleanTruthy)
+{
+    std::vector<bool> bool_vector_t{make_bool_std_vector_truthy()};
+    check_good_case(bool_vector_t, expected_std_vector_value);
+}
+
+TEST(CDRBoolStrictTests, SequenceBooleanTruthy)
+{
+    bool bool_array_t[N_ARR_ELEMENTS]{};
+    make_bool_array_truthy(bool_array_t, N_ARR_ELEMENTS);
+
+    char buffer[BUFFER_LENGTH];
+    {
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_ser(cdrbuffer,
+                eprosima::fastcdr::Cdr::Endianness::LITTLE_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_ser.serialize_sequence(bool_array_t, N_ARR_ELEMENTS));
+    }
+
+    {
+        bool * output_value{nullptr};
+        size_t seq_len{0};
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_des(cdrbuffer,
+                eprosima::fastcdr::Cdr::Endianness::LITTLE_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_des.deserialize_sequence(output_value, seq_len));
+        EXPECT_EQ(seq_len, N_ARR_ELEMENTS);
+        EXPECT_ARRAY_EQ(output_value, expected_array_value, seq_len);
+        free(output_value);
+    }
+
+    {
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_ser(cdrbuffer,
+                eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_ser.serialize_sequence(bool_array_t, N_ARR_ELEMENTS));
+    }
+
+    {
+        bool * output_value{nullptr};
+        size_t seq_len{0};
+        FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+        Cdr cdr_des(cdrbuffer,
+                eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
+        EXPECT_NO_THROW(cdr_des.deserialize_sequence(output_value, seq_len));
+        EXPECT_EQ(seq_len, N_ARR_ELEMENTS);
+        EXPECT_ARRAY_EQ(output_value, expected_array_value, seq_len);
+        free(output_value);
+    }
+}
+
+TEST(FastCDRBoolStrictTests, BooleanTruthy)
+{
+    bool bool_t{make_bool_truthy()};
+
+    char buffer[BUFFER_LENGTH];
+
+    FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+    FastCdr cdr_ser(cdrbuffer);
+
+    EXPECT_NO_THROW({ cdr_ser << bool_t; });
+
+    FastCdr cdr_des(cdrbuffer);
+
+    bool output_value{};
+
+    EXPECT_NO_THROW({ cdr_des >> output_value; });
+
+    EXPECT_EQ(output_value, expected_bool_value);
+}
+
+TEST(FastCDRBoolStrictTests, STDArrayBooleanTruthy)
+{
+    std::array<bool, N_ARR_ELEMENTS> bool_array_t{make_bool_std_array_truthy()};
+
+    char buffer[BUFFER_LENGTH];
+
+    FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+    FastCdr cdr_ser(cdrbuffer);
+
+    EXPECT_NO_THROW({ cdr_ser << bool_array_t; });
+
+    FastCdr cdr_des(cdrbuffer);
+
+    std::array<bool, N_ARR_ELEMENTS> bool_array_value;
+
+    EXPECT_NO_THROW({ cdr_des >> bool_array_value; });
+
+    EXPECT_EQ(bool_array_value, expected_std_array_value);
+}
+
+TEST(FastCDRBoolStrictTests, ArrayBooleanTruthy)
+{
+    bool bool_array_t[N_ARR_ELEMENTS]{};
+    make_bool_array_truthy(bool_array_t, N_ARR_ELEMENTS);
+
+    char buffer[BUFFER_LENGTH];
+
+    FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+    FastCdr cdr_ser(cdrbuffer);
+
+    EXPECT_NO_THROW({ cdr_ser.serialize_array(bool_array_t, N_ARR_ELEMENTS); });
+
+    FastCdr cdr_des(cdrbuffer);
+
+    bool bool_array_value[N_ARR_ELEMENTS];
+
+    EXPECT_NO_THROW({ cdr_des.deserialize_array(bool_array_value, N_ARR_ELEMENTS); });
+
+    EXPECT_ARRAY_EQ(bool_array_value, expected_array_value, N_ARR_ELEMENTS);
+}
+
+TEST(FastCDRBoolStrictTests, STDVectorBooleanTruthy)
+{
+    std::vector<bool> bool_vector_t{make_bool_std_vector_truthy()};
+
+    char buffer[BUFFER_LENGTH];
+
+    FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+    FastCdr cdr_ser(cdrbuffer);
+
+    EXPECT_NO_THROW({ cdr_ser << bool_vector_t; });
+
+    FastCdr cdr_des(cdrbuffer);
+
+    std::vector<bool> bool_vector_value;
+
+    EXPECT_NO_THROW({ cdr_des >> bool_vector_value; });
+
+    EXPECT_EQ(bool_vector_value, expected_std_vector_value);
+}
+
+TEST(FastCDRBoolStrictTests, SequenceBooleanTruthy)
+{
+    bool bool_array_t[N_ARR_ELEMENTS]{};
+    make_bool_array_truthy(bool_array_t, N_ARR_ELEMENTS);
+
+    char buffer[BUFFER_LENGTH];
+
+    FastBuffer cdrbuffer(buffer, BUFFER_LENGTH);
+    FastCdr cdr_ser(cdrbuffer);
+
+    EXPECT_NO_THROW(cdr_ser.serialize_sequence(bool_array_t, N_ARR_ELEMENTS));
+
+    bool * output_value{nullptr};
+    size_t seq_len{0};
+
+    FastCdr cdr_des(cdrbuffer);
+
+    EXPECT_NO_THROW(cdr_des.deserialize_sequence(output_value, seq_len));
+    EXPECT_EQ(seq_len, N_ARR_ELEMENTS);
+    EXPECT_ARRAY_EQ(output_value, expected_array_value, seq_len);
+
+    free(output_value);
+}

--- a/test/cdr/CMakeLists.txt
+++ b/test/cdr/CMakeLists.txt
@@ -36,3 +36,14 @@ add_executable(UnitTests ${UNITTESTS_SOURCE})
 set_common_compile_options(UnitTests)
 target_link_libraries(UnitTests fastcdr GTest::gtest_main)
 gtest_discover_tests(UnitTests)
+
+###############################################################################
+# Bool strict serialization tests
+###############################################################################
+if(STRICT_BOOL)
+    add_executable(BoolStrictTests BoolStrictTest.cpp)
+    set_common_compile_options(BoolStrictTests)
+    target_compile_definitions(BoolStrictTests PRIVATE FASTCDR_STRICT_BOOL)
+    target_link_libraries(BoolStrictTests fastcdr GTest::gtest_main)
+    gtest_discover_tests(BoolStrictTests)
+endif()

--- a/versions.md
+++ b/versions.md
@@ -1,4 +1,5 @@
 # v2.4.0
+* Add STRICT_BOOL CMake option to enforce canonical bool serialization
 
 # v2.3.0
 * Fix symbol visibility for exception classes


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
In release builds, the compiler optimizes the `if (bool_t) { write 1 } else { write 0 }` pattern in all the `bool` serialization paths.

This PR introduces a `STRICT_BOOL` CMake option (off by default), the relative `FASTCDR_STRICT_BOOL` compiler definition and a new `launder_bool()` helper function that uses `memcpy` and a compiler barrier to force normalization of boolean values to 0/1.
A dedicated test file `BoolStrictTest.cpp` has also been included that tests the "truthy" cases.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
Since this is an opt-in, we can backport the new feature to 2.3.x, which is the most used branch.
@Mergifyio backport 2.3.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes #315 

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: CI pass and failing tests are unrelated with the changes.
