### PR TITLE
[24566] Improve checks for sequence lengths

### DIFF
--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -1830,21 +1830,42 @@ public:
     Cdr& deserialize(
             std::array<_T, _Size>& array_t)
     {
+        state state_before_error(*this);
+
         if (CdrVersion::XCDRv2 == cdr_version_ && !is_multi_array_primitive(&array_t))
         {
             uint32_t dheader {0};
             deserialize(dheader);
 
-            uint32_t count {0};
-            auto offset = offset_;
-            while (offset_ - offset < dheader && count < _Size)
+            if ((end_ - offset_) < dheader)
             {
-                deserialize_array(&array_t.data()[count], 1);
-                ++count;
+                set_state(state_before_error);
+                throw exception::NotEnoughMemoryException(
+                          exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
             }
 
-            if (offset_ - offset != dheader)
+            uint32_t count {0};
+            auto offset = offset_;
+            auto last_offset = offset_;
+            last_offset += dheader;
+
+            try
             {
+                while (last_offset - offset_ > 0 && count < _Size)
+                {
+                    deserialize_array(&array_t.data()[count], 1);
+                    ++count;
+                }
+            }
+            catch (exception::Exception& ex)
+            {
+                set_state(state_before_error);
+                ex.raise();
+            }
+
+            if (last_offset - offset_ != 0)
+            {
+                set_state(state_before_error);
                 throw exception::BadParamException("Member size greater than size specified by DHEADER");
             }
         }
@@ -1875,7 +1896,16 @@ public:
             uint32_t dheader {0};
             deserialize(dheader);
 
+            if (((end_ - offset_) < dheader) || (dheader < 4))
+            {
+                set_state(state_before_error);
+                throw exception::NotEnoughMemoryException(
+                          exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+            }
+
             auto offset = offset_;
+            auto last_offset = offset_;
+            last_offset += dheader;
 
             deserialize(sequence_length);
 
@@ -1885,7 +1915,7 @@ public:
             }
             else
             {
-                if ((end_ - offset_) < sequence_length)
+                if ((last_offset - offset_) < sequence_length)
                 {
                     set_state(state_before_error);
                     throw exception::NotEnoughMemoryException(
@@ -1897,7 +1927,7 @@ public:
                     vector_t.resize(sequence_length);
 
                     uint32_t count {0};
-                    while (offset_ - offset < dheader && count < sequence_length)
+                    while (last_offset - offset_ > 0 && count < sequence_length)
                     {
                         deserialize(vector_t.data()[count]);
                         ++count;
@@ -1910,7 +1940,7 @@ public:
                 }
             }
 
-            if (offset_ - offset != dheader)
+            if (last_offset - offset_ != 0)
             {
                 set_state(state_before_error);
                 throw exception::BadParamException("Member size differs from the size specified by DHEADER");
@@ -2015,38 +2045,57 @@ public:
     Cdr& deserialize(
             std::map<_K, _T>& map_t)
     {
+        state state_before_error(*this);
+
         if (CdrVersion::XCDRv2 == cdr_version_)
         {
             uint32_t dheader {0};
             deserialize(dheader);
 
+            if (((end_ - offset_) < dheader) || (dheader < 4))
+            {
+                set_state(state_before_error);
+                throw exception::NotEnoughMemoryException(
+                          exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+            }
+
             auto offset = offset_;
+            auto last_offset = offset_;
+            last_offset += dheader;
 
             uint32_t map_length {0};
             deserialize(map_length);
 
             map_t.clear();
 
-            uint32_t count {0};
-            while (offset_ - offset < dheader && count < map_length)
+            try
             {
-                _K key;
-                _T val;
-                deserialize(key);
-                deserialize(val);
-                map_t.emplace(std::pair<_K, _T>(std::move(key), std::move(val)));
-                ++count;
+                uint32_t count {0};
+                while (last_offset - offset_ > 0 && count < map_length)
+                {
+                    _K key;
+                    _T val;
+                    deserialize(key);
+                    deserialize(val);
+                    map_t.emplace(std::pair<_K, _T>(std::move(key), std::move(val)));
+                    ++count;
+                }
+            }
+            catch (exception::Exception& ex)
+            {
+                set_state(state_before_error);
+                ex.raise();
             }
 
-            if (offset_ - offset != dheader)
+            if (last_offset - offset_ != 0)
             {
+                set_state(state_before_error);
                 throw exception::BadParamException("Member size greater than size specified by DHEADER");
             }
         }
         else
         {
             uint32_t sequence_length = 0;
-            state state_(*this);
 
             deserialize(sequence_length);
 
@@ -2065,7 +2114,7 @@ public:
             }
             catch (exception::Exception& ex)
             {
-                set_state(state_);
+                set_state(state_before_error);
                 ex.raise();
             }
         }
@@ -2421,21 +2470,41 @@ public:
     Cdr& deserialize_array(
             std::vector<_T>& value)
     {
+        state state_before_error(*this);
+
         if (CdrVersion::XCDRv2 == cdr_version_)
         {
             uint32_t dheader {0};
             deserialize(dheader);
 
-            uint32_t count {0};
-            auto offset = offset_;
-            while (offset_ - offset < dheader && count < value.size())
+            if ((end_ - offset_) < dheader)
             {
-                deserialize_array(&value.data()[count], 1);
-                ++count;
+                set_state(state_before_error);
+                throw exception::NotEnoughMemoryException(
+                          exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
             }
 
-            if (offset_ - offset != dheader)
+            uint32_t count {0};
+            auto offset = offset_;
+            auto last_offset = offset_;
+            last_offset += dheader;
+            try
             {
+                while (last_offset - offset_ > 0 && count < value.size())
+                {
+                    deserialize_array(&value.data()[count], 1);
+                    ++count;
+                }
+            }
+            catch (exception::Exception& ex)
+            {
+                set_state(state_before_error);
+                ex.raise();
+            }
+
+            if (offset_ != last_offset)
+            {
+                set_state(state_before_error);
                 throw exception::BadParamException("Member size greater than size specified by DHEADER");
             }
         }
@@ -2516,28 +2585,51 @@ public:
             size_t& num_elements)
     {
         uint32_t sequence_length {0};
+        state state_before_error(*this);
 
         if (CdrVersion::XCDRv2 == cdr_version_)
         {
             uint32_t dheader {0};
             deserialize(dheader);
 
+            if (((end_ - offset_) < dheader) || (dheader < 4))
+            {
+                set_state(state_before_error);
+                throw exception::NotEnoughMemoryException(
+                          exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+            }
+
             auto offset = offset_;
+            auto last_offset = offset_;
+            last_offset += dheader;
 
             deserialize(sequence_length);
+            if (0 == sequence_length)
+            {
+                sequence_t = NULL;
+                num_elements = 0;
+                return *this;
+            }
+
+            if ((last_offset - offset_) < sequence_length)
+            {
+                set_state(state_before_error);
+                throw exception::NotEnoughMemoryException(
+                          exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+            }
 
             try
             {
                 sequence_t = reinterpret_cast<_T*>(calloc(sequence_length, sizeof(_T)));
 
                 uint32_t count {0};
-                while (offset_ - offset < dheader && count < sequence_length)
+                while (last_offset - offset_ > 0 && count < sequence_length)
                 {
                     deserialize(sequence_t[count]);
                     ++count;
                 }
 
-                if (offset_ - offset != dheader)
+                if (last_offset - offset_ != 0)
                 {
                     throw exception::BadParamException("Member size greater than size specified by DHEADER");
                 }
@@ -2546,13 +2638,12 @@ public:
             {
                 free(sequence_t);
                 sequence_t = NULL;
+                set_state(state_before_error);
                 ex.raise();
             }
         }
         else
         {
-            state state_before_error(*this);
-
             deserialize(sequence_length);
 
             if ((end_ - offset_) < sequence_length)

--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -1845,7 +1845,6 @@ public:
             }
 
             uint32_t count {0};
-            auto offset = offset_;
             auto last_offset = offset_;
             last_offset += dheader;
 
@@ -1903,7 +1902,6 @@ public:
                           exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
             }
 
-            auto offset = offset_;
             auto last_offset = offset_;
             last_offset += dheader;
 
@@ -2059,7 +2057,6 @@ public:
                           exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
             }
 
-            auto offset = offset_;
             auto last_offset = offset_;
             last_offset += dheader;
 
@@ -2485,7 +2482,6 @@ public:
             }
 
             uint32_t count {0};
-            auto offset = offset_;
             auto last_offset = offset_;
             last_offset += dheader;
             try
@@ -2599,7 +2595,6 @@ public:
                           exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
             }
 
-            auto offset = offset_;
             auto last_offset = offset_;
             last_offset += dheader;
 

--- a/include/fastcdr/Cdr.h
+++ b/include/fastcdr/Cdr.h
@@ -1868,6 +1868,7 @@ public:
             std::vector<_T>& vector_t)
     {
         uint32_t sequence_length {0};
+        state state_before_error(*this);
 
         if (CdrVersion::XCDRv2 == cdr_version_)
         {
@@ -1881,29 +1882,42 @@ public:
             if (0 == sequence_length)
             {
                 vector_t.clear();
-                return *this;
             }
             else
             {
-                vector_t.resize(sequence_length);
-            }
+                if ((end_ - offset_) < sequence_length)
+                {
+                    set_state(state_before_error);
+                    throw exception::NotEnoughMemoryException(
+                              exception::NotEnoughMemoryException::NOT_ENOUGH_MEMORY_MESSAGE_DEFAULT);
+                }
 
-            uint32_t count {0};
-            while (offset_ - offset < dheader && count < sequence_length)
-            {
-                deserialize(vector_t.data()[count]);
-                ++count;
+                try
+                {
+                    vector_t.resize(sequence_length);
+
+                    uint32_t count {0};
+                    while (offset_ - offset < dheader && count < sequence_length)
+                    {
+                        deserialize(vector_t.data()[count]);
+                        ++count;
+                    }
+                }
+                catch (exception::Exception& ex)
+                {
+                    set_state(state_before_error);
+                    ex.raise();
+                }
             }
 
             if (offset_ - offset != dheader)
             {
+                set_state(state_before_error);
                 throw exception::BadParamException("Member size differs from the size specified by DHEADER");
             }
         }
         else
         {
-            state state_before_error(*this);
-
             deserialize(sequence_length);
 
             if (sequence_length == 0)

--- a/test/cdr/SimpleTest.cpp
+++ b/test/cdr/SimpleTest.cpp
@@ -992,9 +992,9 @@ TEST(CDRTests, STDTripleArrayUnsignedLong)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << triple_ulong_array_t;
-    });
+        {
+            cdr_ser << triple_ulong_array_t;
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1002,9 +1002,9 @@ TEST(CDRTests, STDTripleArrayUnsignedLong)
     std::array<std::array<std::array<uint32_t, 3>, 2>, 2> triple_ulong_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> triple_ulong_array_value;
-    });
+        {
+            cdr_des >> triple_ulong_array_value;
+        });
 
     EXPECT_EQ(triple_ulong_array_value, triple_ulong_array_t);
 
@@ -1016,18 +1016,18 @@ TEST(CDRTests, STDTripleArrayUnsignedLong)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << triple_ulong_array_t;
-    },
+        {
+            cdr_ser_bad << triple_ulong_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> triple_ulong_array_value;
-    },
+        {
+            cdr_des_bad >> triple_ulong_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -1041,9 +1041,9 @@ TEST(CDRTests, SequenceOctet)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(octet_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(octet_seq_t, 5);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1051,9 +1051,9 @@ TEST(CDRTests, SequenceOctet)
     uint8_t* octet_seq_value = NULL; size_t octet_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(octet_seq_value, octet_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(octet_seq_value, octet_seq_len);
+        });
 
     EXPECT_EQ(octet_seq_len, 5u);
     EXPECT_ARRAY_EQ(octet_seq_value, octet_seq_t, octet_seq_len);
@@ -1068,18 +1068,18 @@ TEST(CDRTests, SequenceOctet)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(octet_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(octet_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(octet_seq_value, octet_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(octet_seq_value, octet_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1093,9 +1093,9 @@ TEST(CDRTests, SequenceChar)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(char_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(char_seq_t, 5);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1103,9 +1103,9 @@ TEST(CDRTests, SequenceChar)
     char* char_seq_value = NULL; size_t char_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(char_seq_value, char_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(char_seq_value, char_seq_len);
+        });
 
     EXPECT_EQ(char_seq_len, 5u);
     EXPECT_ARRAY_EQ(char_seq_value, char_seq_t, char_seq_len);
@@ -1120,18 +1120,18 @@ TEST(CDRTests, SequenceChar)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(char_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(char_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(char_seq_value, char_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(char_seq_value, char_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1145,9 +1145,9 @@ TEST(CDRTests, SequenceWChar)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(wchar_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(wchar_seq_t, 5);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1155,9 +1155,9 @@ TEST(CDRTests, SequenceWChar)
     wchar_t* char_seq_value = NULL; size_t char_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(char_seq_value, char_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(char_seq_value, char_seq_len);
+        });
 
     EXPECT_EQ(char_seq_len, 5u);
     EXPECT_ARRAY_EQ(char_seq_value, wchar_seq_t, char_seq_len);
@@ -1172,18 +1172,18 @@ TEST(CDRTests, SequenceWChar)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(wchar_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(wchar_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(char_seq_value, char_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(char_seq_value, char_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1197,9 +1197,9 @@ TEST(CDRTests, SequenceInt8)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(int8_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(int8_seq_t, 5);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1207,9 +1207,9 @@ TEST(CDRTests, SequenceInt8)
     int8_t* int8_seq_value = NULL; size_t int8_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(int8_seq_value, int8_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(int8_seq_value, int8_seq_len);
+        });
 
     EXPECT_EQ(int8_seq_len, 5u);
     EXPECT_ARRAY_EQ(int8_seq_value, int8_seq_t, int8_seq_len);
@@ -1224,18 +1224,18 @@ TEST(CDRTests, SequenceInt8)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(int8_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(int8_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(int8_seq_value, int8_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(int8_seq_value, int8_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1249,9 +1249,9 @@ TEST(CDRTests, SequenceUnsignedShort)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(ushort_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(ushort_seq_t, 5);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1259,9 +1259,9 @@ TEST(CDRTests, SequenceUnsignedShort)
     uint16_t* ushort_seq_value = NULL; size_t ushort_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(ushort_seq_value, ushort_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(ushort_seq_value, ushort_seq_len);
+        });
 
     EXPECT_EQ(ushort_seq_len, 5u);
     EXPECT_ARRAY_EQ(ushort_seq_value, ushort_seq_t, ushort_seq_len);
@@ -1276,18 +1276,18 @@ TEST(CDRTests, SequenceUnsignedShort)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(ushort_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(ushort_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(ushort_seq_value, ushort_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(ushort_seq_value, ushort_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1301,9 +1301,9 @@ TEST(CDRTests, SequenceShort)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(short_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(short_seq_t, 5);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1311,9 +1311,9 @@ TEST(CDRTests, SequenceShort)
     int16_t* short_seq_value = NULL; size_t short_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(short_seq_value, short_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(short_seq_value, short_seq_len);
+        });
 
     EXPECT_EQ(short_seq_len, 5u);
     EXPECT_ARRAY_EQ(short_seq_value, short_seq_t, short_seq_len);
@@ -1328,18 +1328,18 @@ TEST(CDRTests, SequenceShort)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(short_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(short_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(short_seq_value, short_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(short_seq_value, short_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1353,9 +1353,9 @@ TEST(CDRTests, SequenceUnsignedLong)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(ulong_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(ulong_seq_t, 5);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1363,9 +1363,9 @@ TEST(CDRTests, SequenceUnsignedLong)
     uint32_t* ulong_seq_value = NULL; size_t ulong_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(ulong_seq_value, ulong_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(ulong_seq_value, ulong_seq_len);
+        });
 
     EXPECT_EQ(ulong_seq_len, 5u);
     EXPECT_ARRAY_EQ(ulong_seq_value, ulong_seq_t, ulong_seq_len);
@@ -1380,18 +1380,18 @@ TEST(CDRTests, SequenceUnsignedLong)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(ulong_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(ulong_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(ulong_seq_value, ulong_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(ulong_seq_value, ulong_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1405,9 +1405,9 @@ TEST(CDRTests, SequenceLong)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(long_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(long_seq_t, 5);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1415,9 +1415,9 @@ TEST(CDRTests, SequenceLong)
     int32_t* long_seq_value = NULL; size_t long_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(long_seq_value, long_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(long_seq_value, long_seq_len);
+        });
 
     EXPECT_EQ(long_seq_len, 5u);
     EXPECT_ARRAY_EQ(long_seq_value, long_seq_t, long_seq_len);
@@ -1432,18 +1432,18 @@ TEST(CDRTests, SequenceLong)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(long_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(long_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(long_seq_value, long_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(long_seq_value, long_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1457,9 +1457,9 @@ TEST(CDRTests, SequenceUnsignedLongLong)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(ulonglong_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(ulonglong_seq_t, 5);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1467,9 +1467,9 @@ TEST(CDRTests, SequenceUnsignedLongLong)
     uint64_t* ulonglong_seq_value = NULL; size_t ulonglong_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(ulonglong_seq_value, ulonglong_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(ulonglong_seq_value, ulonglong_seq_len);
+        });
 
     EXPECT_EQ(ulonglong_seq_len, 5u);
     EXPECT_ARRAY_EQ(ulonglong_seq_value, ulonglong_seq_t, ulonglong_seq_len);
@@ -1484,18 +1484,18 @@ TEST(CDRTests, SequenceUnsignedLongLong)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(ulonglong_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(ulonglong_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(ulonglong_seq_value, ulonglong_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(ulonglong_seq_value, ulonglong_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1509,9 +1509,9 @@ TEST(CDRTests, SequenceLongLong)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(longlong_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(longlong_seq_t, 5);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1519,9 +1519,9 @@ TEST(CDRTests, SequenceLongLong)
     int64_t* longlong_seq_value = NULL; size_t longlong_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(longlong_seq_value, longlong_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(longlong_seq_value, longlong_seq_len);
+        });
 
     EXPECT_EQ(longlong_seq_len, 5u);
     EXPECT_ARRAY_EQ(longlong_seq_value, longlong_seq_t, longlong_seq_len);
@@ -1536,18 +1536,18 @@ TEST(CDRTests, SequenceLongLong)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(longlong_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(longlong_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(longlong_seq_value, longlong_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(longlong_seq_value, longlong_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1561,9 +1561,9 @@ TEST(CDRTests, SequenceFloat)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(float_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(float_seq_t, 5);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1571,9 +1571,9 @@ TEST(CDRTests, SequenceFloat)
     float* float_seq_value = NULL; size_t float_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(float_seq_value, float_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(float_seq_value, float_seq_len);
+        });
 
     EXPECT_EQ(float_seq_len, 5u);
     EXPECT_ARRAY_FLOAT_EQ(float_seq_value, float_seq_t, float_seq_len);
@@ -1588,18 +1588,18 @@ TEST(CDRTests, SequenceFloat)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(float_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(float_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(float_seq_value, float_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(float_seq_value, float_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1613,9 +1613,9 @@ TEST(CDRTests, SequenceDouble)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(double_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(double_seq_t, 5);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1623,9 +1623,9 @@ TEST(CDRTests, SequenceDouble)
     double* double_seq_value = NULL; size_t double_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(double_seq_value, double_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(double_seq_value, double_seq_len);
+        });
 
     EXPECT_EQ(double_seq_len, 5u);
     EXPECT_ARRAY_DOUBLE_EQ(double_seq_value, double_seq_t, double_seq_len);
@@ -1640,18 +1640,18 @@ TEST(CDRTests, SequenceDouble)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(double_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(double_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(double_seq_value, double_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(double_seq_value, double_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1665,9 +1665,9 @@ TEST(CDRTests, SequenceLongDouble)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(ldouble_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(ldouble_seq_t, 5);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1675,9 +1675,9 @@ TEST(CDRTests, SequenceLongDouble)
     long double* ldouble_seq_value = NULL; size_t ldouble_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(ldouble_seq_value, ldouble_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(ldouble_seq_value, ldouble_seq_len);
+        });
 
     EXPECT_EQ(ldouble_seq_len, 5u);
     EXPECT_ARRAY_LONG_DOUBLE_EQ(ldouble_seq_value, ldouble_seq_t, ldouble_seq_len);
@@ -1692,18 +1692,18 @@ TEST(CDRTests, SequenceLongDouble)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(ldouble_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(ldouble_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(ldouble_seq_value, ldouble_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(ldouble_seq_value, ldouble_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1717,9 +1717,9 @@ TEST(CDRTests, SequenceBoolean)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(bool_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(bool_seq_t, 5);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1727,9 +1727,9 @@ TEST(CDRTests, SequenceBoolean)
     bool* bool_seq_value = NULL; size_t bool_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(bool_seq_value, bool_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(bool_seq_value, bool_seq_len);
+        });
 
     EXPECT_EQ(bool_seq_len, 5u);
     EXPECT_ARRAY_EQ(bool_seq_value, bool_seq_t, bool_seq_len);
@@ -1744,18 +1744,18 @@ TEST(CDRTests, SequenceBoolean)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(bool_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(bool_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(bool_seq_value, bool_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(bool_seq_value, bool_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1769,9 +1769,9 @@ TEST(CDRTests, SequenceString)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(string_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(string_seq_t, 5);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1779,9 +1779,9 @@ TEST(CDRTests, SequenceString)
     std::string* string_seq_value = NULL; size_t string_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(string_seq_value, string_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(string_seq_value, string_seq_len);
+        });
 
     EXPECT_EQ(string_seq_len, 5u);
     EXPECT_ARRAY_EQ(string_seq_value, string_seq_t, string_seq_len);
@@ -1796,18 +1796,18 @@ TEST(CDRTests, SequenceString)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(string_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(string_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(string_seq_value, string_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(string_seq_value, string_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1821,9 +1821,9 @@ TEST(CDRTests, SequenceWString)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(wstring_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(wstring_seq_t, 5);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1831,9 +1831,9 @@ TEST(CDRTests, SequenceWString)
     std::wstring* string_seq_value = NULL; size_t string_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(string_seq_value, string_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(string_seq_value, string_seq_len);
+        });
 
     EXPECT_EQ(string_seq_len, 5u);
     EXPECT_ARRAY_EQ(string_seq_value, wstring_seq_t, string_seq_len);
@@ -1848,18 +1848,18 @@ TEST(CDRTests, SequenceWString)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(wstring_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(wstring_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(string_seq_value, string_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(string_seq_value, string_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1873,9 +1873,9 @@ TEST(CDRTests, CString)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize(c_string_t);
-    });
+        {
+            cdr_ser.serialize(c_string_t);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1883,9 +1883,9 @@ TEST(CDRTests, CString)
     char* c_string_value = NULL;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize(c_string_value);
-    });
+        {
+            cdr_des.deserialize(c_string_value);
+        });
 
     EXPECT_EQ(strcmp(c_string_value, c_string_t), 0);
 
@@ -1899,18 +1899,18 @@ TEST(CDRTests, CString)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize(c_string_t);
-    },
+        {
+            cdr_ser_bad.serialize(c_string_t);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize(c_string_value);
-    },
+        {
+            cdr_des_bad.deserialize(c_string_value);
+        },
         NotEnoughMemoryException);
 }
 
@@ -1924,9 +1924,9 @@ TEST(CDRTests, CWString)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize(c_wstring_t);
-    });
+        {
+            cdr_ser.serialize(c_wstring_t);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -1934,9 +1934,9 @@ TEST(CDRTests, CWString)
     wchar_t* c_string_value = NULL;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize(c_string_value);
-    });
+        {
+            cdr_des.deserialize(c_string_value);
+        });
 
     EXPECT_EQ(wcscmp(c_string_value, c_wstring_t), 0);
 
@@ -1950,9 +1950,9 @@ TEST(CDRTests, CWString)
     Cdr cdr_ser_bigendi(cdrbuffer_bigendi, eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_bigendi.serialize(c_wstring_t);
-    });
+        {
+            cdr_ser_bigendi.serialize(c_wstring_t);
+        });
 
     // Deserialization.
     Cdr cdr_des_bigendi(cdrbuffer_bigendi, eprosima::fastcdr::Cdr::Endianness::BIG_ENDIANNESS);
@@ -1960,9 +1960,9 @@ TEST(CDRTests, CWString)
     wchar_t* c_wstring_bigendi {nullptr};
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_bigendi.deserialize(c_wstring_bigendi);
-    });
+        {
+            cdr_des_bigendi.deserialize(c_wstring_bigendi);
+        });
 
     EXPECT_EQ(wcscmp(c_wstring_bigendi, c_wstring_t), 0);
 
@@ -1976,18 +1976,18 @@ TEST(CDRTests, CWString)
     Cdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize(c_wstring_t);
-    },
+        {
+            cdr_ser_bad.serialize(c_wstring_t);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     Cdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize(c_string_value);
-    },
+        {
+            cdr_des_bad.deserialize(c_string_value);
+        },
         NotEnoughMemoryException);
 }
 
@@ -2000,45 +2000,52 @@ TEST(CDRTests, Complete)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << octet_t << char_t << int8 << ushort_t << short_t << ulong_t << long_t << ulonglong_t << longlong_t <<
-            float_tt << double_tt << ldouble_tt << bool_t << string_t;
-        cdr_ser << octet_array_t << char_array_t << int8_array_t << ushort_array_t << short_array_t << ulong_array_t <<
-            long_array_t << ulonglong_array_t << longlong_array_t << float_array_t << double_array_t << ldouble_array_t << bool_array_t;
-        cdr_ser.serialize_array(octet_array_2_t,
-        5).serialize_array(char_array_2_t, 5).serialize_array(int8_array_2_t, 5).
-                serialize_array(ushort_array_2_t, 5).serialize_array(short_array_2_t,
-        5).serialize_array(ulong_array_2_t,
-        5).
-                serialize_array(long_array_2_t, 5).serialize_array(ulonglong_array_2_t,
-        5).serialize_array(longlong_array_2_t, 5).
-                serialize_array(float_array_2_t, 5).serialize_array(double_array_2_t,
-        5).serialize_array(ldouble_array_2_t,
-        5).serialize_array(
-            bool_array_2_t,
+        {
+            cdr_ser << octet_t << char_t << int8 << ushort_t << short_t << ulong_t << long_t << ulonglong_t
+                    << longlong_t
+                    << float_tt << double_tt << ldouble_tt << bool_t << string_t;
+            cdr_ser << octet_array_t << char_array_t << int8_array_t << ushort_array_t << short_array_t << ulong_array_t
+                    << long_array_t << ulonglong_array_t << longlong_array_t << float_array_t << double_array_t
+                    << ldouble_array_t << bool_array_t;
+            cdr_ser.serialize_array(octet_array_2_t,
+            5).serialize_array(char_array_2_t, 5).serialize_array(int8_array_2_t, 5).
+                    serialize_array(ushort_array_2_t, 5).serialize_array(short_array_2_t,
+            5).serialize_array(ulong_array_2_t,
+            5).
+                    serialize_array(long_array_2_t, 5).serialize_array(ulonglong_array_2_t,
+            5).serialize_array(longlong_array_2_t, 5).
+                    serialize_array(float_array_2_t, 5).serialize_array(double_array_2_t,
+            5).serialize_array(ldouble_array_2_t,
+            5).serialize_array(
+                bool_array_2_t,
+                5);
+            cdr_ser << octet_vector_t << char_vector_t << int8_vector_t << ushort_vector_t << short_vector_t
+                    << ulong_vector_t
+                    << long_vector_t << ulonglong_vector_t << longlong_vector_t << float_vector_t << double_vector_t
+                    << ldouble_vector_t << bool_vector_t;
+            cdr_ser << triple_ulong_array_t;
+            cdr_ser.serialize_sequence(octet_seq_t, 5).serialize_sequence(char_seq_t, 5).serialize_sequence(int8_seq_t,
+            5).
+                    serialize_sequence(ushort_seq_t, 5).serialize_sequence(short_seq_t,
+            5).serialize_sequence(ulong_seq_t,
+            5).
+                    serialize_sequence(long_seq_t, 5).serialize_sequence(ulonglong_seq_t,
+            5).serialize_sequence(longlong_seq_t,
+            5).
+                    serialize_sequence(float_seq_t, 5).serialize_sequence(double_seq_t,
+            5).serialize_sequence(ldouble_seq_t,
             5);
-        cdr_ser << octet_vector_t << char_vector_t << int8_vector_t << ushort_vector_t << short_vector_t << ulong_vector_t <<
-            long_vector_t << ulonglong_vector_t << longlong_vector_t << float_vector_t << double_vector_t << ldouble_vector_t << bool_vector_t;
-        cdr_ser << triple_ulong_array_t;
-        cdr_ser.serialize_sequence(octet_seq_t, 5).serialize_sequence(char_seq_t, 5).serialize_sequence(int8_seq_t, 5).
-                serialize_sequence(ushort_seq_t, 5).serialize_sequence(short_seq_t, 5).serialize_sequence(ulong_seq_t,
-        5).
-                serialize_sequence(long_seq_t, 5).serialize_sequence(ulonglong_seq_t,
-        5).serialize_sequence(longlong_seq_t,
-        5).
-                serialize_sequence(float_seq_t, 5).serialize_sequence(double_seq_t, 5).serialize_sequence(ldouble_seq_t,
-        5);
-        cdr_ser.serialize(c_string_t);
-        // Wstring and wchar
-        cdr_ser << wchar << wstring_t;
-        cdr_ser.serialize_array(wchar_array_2_t, 5).serialize_array(wstring_array_2_t, 5);
-        cdr_ser << wchar_array_t << wstring_array_t;
-        cdr_ser << wchar_vector_t << wstring_vector_t;
-        cdr_ser.serialize_sequence(wchar_seq_t, 5);
-        cdr_ser.serialize_sequence(wstring_seq_t, 5);
-        cdr_ser.serialize_sequence(string_seq_t, 5);
-        cdr_ser.serialize(c_wstring_t);
-    });
+            cdr_ser.serialize(c_string_t);
+            // Wstring and wchar
+            cdr_ser << wchar << wstring_t;
+            cdr_ser.serialize_array(wchar_array_2_t, 5).serialize_array(wstring_array_2_t, 5);
+            cdr_ser << wchar_array_t << wstring_array_t;
+            cdr_ser << wchar_vector_t << wstring_vector_t;
+            cdr_ser.serialize_sequence(wchar_seq_t, 5);
+            cdr_ser.serialize_sequence(wstring_seq_t, 5);
+            cdr_ser.serialize_sequence(string_seq_t, 5);
+            cdr_ser.serialize(c_wstring_t);
+        });
 
     // Deserialization.
     Cdr cdr_des(cdrbuffer);
@@ -2124,48 +2131,55 @@ TEST(CDRTests, Complete)
     std::string* string_seq_value = NULL; size_t string_seq_len;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> octet_value >> char_value >> int8_value >> ushort_value >> short_value >> ulong_value >> long_value >>
-        ulonglong_value >> longlong_value >> float_value >> double_value >> ldouble_value  >> bool_value >> string_value;
-        cdr_des >> octet_array_value >> char_array_value >> int8_array_value >> ushort_array_value >> short_array_value >>
-        ulong_array_value >> long_array_value >> ulonglong_array_value >> longlong_array_value >> float_array_value >>
-        double_array_value >> ldouble_array_value >> bool_array_value;
-        cdr_des.deserialize_array(octet_array_2_value,
-        5).deserialize_array(char_array_2_value, 5).deserialize_array(int8_array_2_value, 5).
-                deserialize_array(ushort_array_2_value, 5).deserialize_array(short_array_2_value,
-        5).deserialize_array(ulong_array_2_value, 5).
-                deserialize_array(long_array_2_value, 5).deserialize_array(ulonglong_array_2_value,
-        5).deserialize_array(longlong_array_2_value, 5).
-                deserialize_array(float_array_2_value, 5).deserialize_array(double_array_2_value,
-        5).deserialize_array(ldouble_array_2_value, 5).
-                deserialize_array(bool_array_2_value,
-        5);
-        cdr_des >> octet_vector_value >> char_vector_value >> int8_vector_value >> ushort_vector_value >> short_vector_value >>
-        ulong_vector_value >> long_vector_value >> ulonglong_vector_value >> longlong_vector_value >> float_vector_value >>
-        double_vector_value >> ldouble_vector_value >> bool_vector_value;
-        cdr_des >> triple_ulong_array_value;
-        cdr_des.deserialize_sequence(octet_seq_value, octet_seq_len).deserialize_sequence(char_seq_value, char_seq_len).
-                deserialize_sequence(int8_seq_value, int8_seq_len).deserialize_sequence(ushort_seq_value,
-        ushort_seq_len).
-                deserialize_sequence(short_seq_value, short_seq_len).deserialize_sequence(ulong_seq_value,
-        ulong_seq_len).
-                deserialize_sequence(long_seq_value, long_seq_len).deserialize_sequence(ulonglong_seq_value,
-        ulonglong_seq_len).
-                deserialize_sequence(longlong_seq_value, longlong_seq_len).deserialize_sequence(float_seq_value,
-        float_seq_len).
-                deserialize_sequence(double_seq_value, double_seq_len).deserialize_sequence(ldouble_seq_value,
-        ldouble_seq_len);
-        cdr_des.deserialize(c_string_value);
-        // WString and wchar_t
-        cdr_des >> wchar_value >> wstring_value;
-        cdr_des.deserialize_array(wchar_array_2_value, 5).deserialize_array(wstring_array_2_value, 5);
-        cdr_des >> wchar_array_value >> wstring_array_value;
-        cdr_des >> wchar_vector_value >> wstring_vector_value;
-        cdr_des.deserialize_sequence(wchar_seq_value, wchar_seq_len);
-        cdr_des.deserialize_sequence(wstring_seq_value, wstring_seq_len);
-        cdr_des.deserialize_sequence(string_seq_value, string_seq_len);
-        cdr_des.deserialize(c_wstring_value);
-    });
+        {
+            cdr_des >> octet_value >> char_value >> int8_value >> ushort_value >> short_value >> ulong_value
+            >> long_value
+            >> ulonglong_value >> longlong_value >> float_value >> double_value >> ldouble_value  >> bool_value
+            >> string_value;
+            cdr_des >> octet_array_value >> char_array_value >> int8_array_value >> ushort_array_value
+            >> short_array_value
+            >> ulong_array_value >> long_array_value >> ulonglong_array_value >> longlong_array_value
+            >> float_array_value
+            >> double_array_value >> ldouble_array_value >> bool_array_value;
+            cdr_des.deserialize_array(octet_array_2_value,
+            5).deserialize_array(char_array_2_value, 5).deserialize_array(int8_array_2_value, 5).
+                    deserialize_array(ushort_array_2_value, 5).deserialize_array(short_array_2_value,
+            5).deserialize_array(ulong_array_2_value, 5).
+                    deserialize_array(long_array_2_value, 5).deserialize_array(ulonglong_array_2_value,
+            5).deserialize_array(longlong_array_2_value, 5).
+                    deserialize_array(float_array_2_value, 5).deserialize_array(double_array_2_value,
+            5).deserialize_array(ldouble_array_2_value, 5).
+                    deserialize_array(bool_array_2_value,
+            5);
+            cdr_des >> octet_vector_value >> char_vector_value >> int8_vector_value >> ushort_vector_value
+            >> short_vector_value
+            >> ulong_vector_value >> long_vector_value >> ulonglong_vector_value >> longlong_vector_value
+            >> float_vector_value
+            >> double_vector_value >> ldouble_vector_value >> bool_vector_value;
+            cdr_des >> triple_ulong_array_value;
+            cdr_des.deserialize_sequence(octet_seq_value, octet_seq_len).deserialize_sequence(char_seq_value,
+            char_seq_len).
+                    deserialize_sequence(int8_seq_value, int8_seq_len).deserialize_sequence(ushort_seq_value,
+            ushort_seq_len).
+                    deserialize_sequence(short_seq_value, short_seq_len).deserialize_sequence(ulong_seq_value,
+            ulong_seq_len).
+                    deserialize_sequence(long_seq_value, long_seq_len).deserialize_sequence(ulonglong_seq_value,
+            ulonglong_seq_len).
+                    deserialize_sequence(longlong_seq_value, longlong_seq_len).deserialize_sequence(float_seq_value,
+            float_seq_len).
+                    deserialize_sequence(double_seq_value, double_seq_len).deserialize_sequence(ldouble_seq_value,
+            ldouble_seq_len);
+            cdr_des.deserialize(c_string_value);
+            // WString and wchar_t
+            cdr_des >> wchar_value >> wstring_value;
+            cdr_des.deserialize_array(wchar_array_2_value, 5).deserialize_array(wstring_array_2_value, 5);
+            cdr_des >> wchar_array_value >> wstring_array_value;
+            cdr_des >> wchar_vector_value >> wstring_vector_value;
+            cdr_des.deserialize_sequence(wchar_seq_value, wchar_seq_len);
+            cdr_des.deserialize_sequence(wstring_seq_value, wstring_seq_len);
+            cdr_des.deserialize_sequence(string_seq_value, string_seq_len);
+            cdr_des.deserialize(c_wstring_value);
+        });
 
     EXPECT_EQ(octet_value, octet_t);
     EXPECT_EQ(char_value, char_t);
@@ -2327,9 +2341,9 @@ TEST(FastCDRTests, Octet)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << octet_t;
-    });
+        {
+            cdr_ser << octet_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -2337,9 +2351,9 @@ TEST(FastCDRTests, Octet)
     uint8_t octet_value = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> octet_value;
-    });
+        {
+            cdr_des >> octet_value;
+        });
 
     EXPECT_EQ(octet_value, octet_t);
 }
@@ -2354,9 +2368,9 @@ TEST(FastCDRTests, Char)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << char_t;
-    });
+        {
+            cdr_ser << char_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -2364,9 +2378,9 @@ TEST(FastCDRTests, Char)
     char char_value = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> char_value;
-    });
+        {
+            cdr_des >> char_value;
+        });
 
     EXPECT_EQ(char_value, char_t);
 }
@@ -2381,9 +2395,9 @@ TEST(FastCDRTests, WChar)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << wchar;
-    });
+        {
+            cdr_ser << wchar;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -2391,9 +2405,9 @@ TEST(FastCDRTests, WChar)
     wchar_t char_value = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> char_value;
-    });
+        {
+            cdr_des >> char_value;
+        });
 
     EXPECT_EQ(char_value, wchar);
 }
@@ -2408,9 +2422,9 @@ TEST(FastCDRTests, Int8)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << int8;
-    });
+        {
+            cdr_ser << int8;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -2418,9 +2432,9 @@ TEST(FastCDRTests, Int8)
     int8_t int8_value = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> int8_value;
-    });
+        {
+            cdr_des >> int8_value;
+        });
 
     EXPECT_EQ(int8_value, int8);
 }
@@ -2435,9 +2449,9 @@ TEST(FastCDRTests, UnsignedShort)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << ushort_t;
-    });
+        {
+            cdr_ser << ushort_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -2445,9 +2459,9 @@ TEST(FastCDRTests, UnsignedShort)
     uint16_t ushort_value = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> ushort_value;
-    });
+        {
+            cdr_des >> ushort_value;
+        });
 
     EXPECT_EQ(ushort_value, ushort_t);
 
@@ -2459,18 +2473,18 @@ TEST(FastCDRTests, UnsignedShort)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << ushort_t;
-    },
+        {
+            cdr_ser_bad << ushort_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> ushort_value;
-    },
+        {
+            cdr_des_bad >> ushort_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -2484,9 +2498,9 @@ TEST(FastCDRTests, Short)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << short_t;
-    });
+        {
+            cdr_ser << short_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -2494,9 +2508,9 @@ TEST(FastCDRTests, Short)
     int16_t short_value = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> short_value;
-    });
+        {
+            cdr_des >> short_value;
+        });
 
     EXPECT_EQ(short_value, short_t);
 
@@ -2508,18 +2522,18 @@ TEST(FastCDRTests, Short)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << short_t;
-    },
+        {
+            cdr_ser_bad << short_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> short_value;
-    },
+        {
+            cdr_des_bad >> short_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -2533,9 +2547,9 @@ TEST(FastCDRTests, UnsignedLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << ulong_t;
-    });
+        {
+            cdr_ser << ulong_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -2543,9 +2557,9 @@ TEST(FastCDRTests, UnsignedLong)
     uint32_t ulong_value = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> ulong_value;
-    });
+        {
+            cdr_des >> ulong_value;
+        });
 
     EXPECT_EQ(ulong_value, ulong_t);
 
@@ -2557,18 +2571,18 @@ TEST(FastCDRTests, UnsignedLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << ulong_t;
-    },
+        {
+            cdr_ser_bad << ulong_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> ulong_value;
-    },
+        {
+            cdr_des_bad >> ulong_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -2582,9 +2596,9 @@ TEST(FastCDRTests, Long)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << long_t;
-    });
+        {
+            cdr_ser << long_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -2592,9 +2606,9 @@ TEST(FastCDRTests, Long)
     int32_t long_value = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> long_value;
-    });
+        {
+            cdr_des >> long_value;
+        });
 
     EXPECT_EQ(long_value, long_t);
 
@@ -2606,18 +2620,18 @@ TEST(FastCDRTests, Long)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << long_t;
-    },
+        {
+            cdr_ser_bad << long_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> long_value;
-    },
+        {
+            cdr_des_bad >> long_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -2631,9 +2645,9 @@ TEST(FastCDRTests, UnsignedLongLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << ulonglong_t;
-    });
+        {
+            cdr_ser << ulonglong_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -2641,9 +2655,9 @@ TEST(FastCDRTests, UnsignedLongLong)
     uint64_t ulonglong_value = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> ulonglong_value;
-    });
+        {
+            cdr_des >> ulonglong_value;
+        });
 
     EXPECT_EQ(ulonglong_value, ulonglong_t);
 
@@ -2655,18 +2669,18 @@ TEST(FastCDRTests, UnsignedLongLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << ulonglong_t;
-    },
+        {
+            cdr_ser_bad << ulonglong_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> ulonglong_value;
-    },
+        {
+            cdr_des_bad >> ulonglong_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -2680,9 +2694,9 @@ TEST(FastCDRTests, LongLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << longlong_t;
-    });
+        {
+            cdr_ser << longlong_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -2690,9 +2704,9 @@ TEST(FastCDRTests, LongLong)
     int64_t longlong_value = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> longlong_value;
-    });
+        {
+            cdr_des >> longlong_value;
+        });
 
     EXPECT_EQ(longlong_value, longlong_t);
 
@@ -2704,18 +2718,18 @@ TEST(FastCDRTests, LongLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << longlong_t;
-    },
+        {
+            cdr_ser_bad << longlong_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> longlong_value;
-    },
+        {
+            cdr_des_bad >> longlong_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -2729,9 +2743,9 @@ TEST(FastCDRTests, Float)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << float_tt;
-    });
+        {
+            cdr_ser << float_tt;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -2739,9 +2753,9 @@ TEST(FastCDRTests, Float)
     float float_value = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> float_value;
-    });
+        {
+            cdr_des >> float_value;
+        });
 
     EXPECT_FLOAT_EQ(float_value, float_tt);
 
@@ -2753,18 +2767,18 @@ TEST(FastCDRTests, Float)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << float_tt;
-    },
+        {
+            cdr_ser_bad << float_tt;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> float_value;
-    },
+        {
+            cdr_des_bad >> float_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -2778,9 +2792,9 @@ TEST(FastCDRTests, Double)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << double_tt;
-    });
+        {
+            cdr_ser << double_tt;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -2788,9 +2802,9 @@ TEST(FastCDRTests, Double)
     double double_value = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> double_value;
-    });
+        {
+            cdr_des >> double_value;
+        });
 
     EXPECT_DOUBLE_EQ(double_value, double_tt);
 
@@ -2802,18 +2816,18 @@ TEST(FastCDRTests, Double)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << double_tt;
-    },
+        {
+            cdr_ser_bad << double_tt;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> double_value;
-    },
+        {
+            cdr_des_bad >> double_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -2827,9 +2841,9 @@ TEST(FastCDRTests, LongDouble)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << ldouble_tt;
-    });
+        {
+            cdr_ser << ldouble_tt;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -2837,9 +2851,9 @@ TEST(FastCDRTests, LongDouble)
     long double ldouble_value = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> ldouble_value;
-    });
+        {
+            cdr_des >> ldouble_value;
+        });
 
     EXPECT_LONG_DOUBLE_EQ(ldouble_value, ldouble_tt);
 
@@ -2851,18 +2865,18 @@ TEST(FastCDRTests, LongDouble)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << ldouble_tt;
-    },
+        {
+            cdr_ser_bad << ldouble_tt;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> ldouble_value;
-    },
+        {
+            cdr_des_bad >> ldouble_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -2876,9 +2890,9 @@ TEST(FastCDRTests, Boolean)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << bool_t;
-    });
+        {
+            cdr_ser << bool_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -2886,9 +2900,9 @@ TEST(FastCDRTests, Boolean)
     bool bool_value = false;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> bool_value;
-    });
+        {
+            cdr_des >> bool_value;
+        });
 
     EXPECT_EQ(bool_value, bool_t);
 }
@@ -2903,9 +2917,9 @@ TEST(FastCDRTests, String)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << string_t;
-    });
+        {
+            cdr_ser << string_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -2913,9 +2927,9 @@ TEST(FastCDRTests, String)
     std::string string_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> string_value;
-    });
+        {
+            cdr_des >> string_value;
+        });
 
     EXPECT_EQ(string_value, string_t);
 
@@ -2927,18 +2941,18 @@ TEST(FastCDRTests, String)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << string_t;
-    },
+        {
+            cdr_ser_bad << string_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> string_value;
-    },
+        {
+            cdr_des_bad >> string_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -2952,9 +2966,9 @@ TEST(FastCDRTests, WString)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << wstring_t;
-    });
+        {
+            cdr_ser << wstring_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -2962,9 +2976,9 @@ TEST(FastCDRTests, WString)
     std::wstring string_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> string_value;
-    });
+        {
+            cdr_des >> string_value;
+        });
 
     EXPECT_EQ(string_value, wstring_t);
 
@@ -2976,18 +2990,18 @@ TEST(FastCDRTests, WString)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << wstring_t;
-    },
+        {
+            cdr_ser_bad << wstring_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> string_value;
-    },
+        {
+            cdr_des_bad >> string_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3001,9 +3015,9 @@ TEST(FastCDRTests, EmptyString)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << emptystring_t;
-    });
+        {
+            cdr_ser << emptystring_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3011,9 +3025,9 @@ TEST(FastCDRTests, EmptyString)
     std::string string_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> string_value;
-    });
+        {
+            cdr_des >> string_value;
+        });
 
     EXPECT_EQ(string_value, emptystring_t);
 
@@ -3025,18 +3039,18 @@ TEST(FastCDRTests, EmptyString)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << emptystring_t;
-    },
+        {
+            cdr_ser_bad << emptystring_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> string_value;
-    },
+        {
+            cdr_des_bad >> string_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3050,9 +3064,9 @@ TEST(FastCDRTests, EmptyWString)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << emptywstring_t;
-    });
+        {
+            cdr_ser << emptywstring_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3060,9 +3074,9 @@ TEST(FastCDRTests, EmptyWString)
     std::wstring wstring_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> wstring_value;
-    });
+        {
+            cdr_des >> wstring_value;
+        });
 
     EXPECT_EQ(wstring_value, emptywstring_t);
 
@@ -3074,18 +3088,18 @@ TEST(FastCDRTests, EmptyWString)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << emptywstring_t;
-    },
+        {
+            cdr_ser_bad << emptywstring_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> wstring_value;
-    },
+        {
+            cdr_des_bad >> wstring_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3099,9 +3113,9 @@ TEST(FastCDRTests, STDArrayOctet)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << octet_array_t;
-    });
+        {
+            cdr_ser << octet_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3109,9 +3123,9 @@ TEST(FastCDRTests, STDArrayOctet)
     std::array<uint8_t, N_ARR_ELEMENTS> octet_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> octet_array_value;
-    });
+        {
+            cdr_des >> octet_array_value;
+        });
 
     EXPECT_EQ(octet_array_value, octet_array_t);
 
@@ -3123,18 +3137,18 @@ TEST(FastCDRTests, STDArrayOctet)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << octet_array_t;
-    },
+        {
+            cdr_ser_bad << octet_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> octet_array_value;
-    },
+        {
+            cdr_des_bad >> octet_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3148,9 +3162,9 @@ TEST(FastCDRTests, STDArrayChar)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << char_array_t;
-    });
+        {
+            cdr_ser << char_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3158,9 +3172,9 @@ TEST(FastCDRTests, STDArrayChar)
     std::array<char, N_ARR_ELEMENTS> char_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> char_array_value;
-    });
+        {
+            cdr_des >> char_array_value;
+        });
 
     EXPECT_EQ(char_array_value, char_array_t);
 
@@ -3172,18 +3186,18 @@ TEST(FastCDRTests, STDArrayChar)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << char_array_t;
-    },
+        {
+            cdr_ser_bad << char_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> char_array_value;
-    },
+        {
+            cdr_des_bad >> char_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3197,9 +3211,9 @@ TEST(FastCDRTests, STDArrayWChar)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << wchar_array_t;
-    });
+        {
+            cdr_ser << wchar_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3207,9 +3221,9 @@ TEST(FastCDRTests, STDArrayWChar)
     std::array<wchar_t, N_ARR_ELEMENTS> char_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> char_array_value;
-    });
+        {
+            cdr_des >> char_array_value;
+        });
 
     EXPECT_EQ(char_array_value, wchar_array_t);
 
@@ -3221,18 +3235,18 @@ TEST(FastCDRTests, STDArrayWChar)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << wchar_array_t;
-    },
+        {
+            cdr_ser_bad << wchar_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> char_array_value;
-    },
+        {
+            cdr_des_bad >> char_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3246,9 +3260,9 @@ TEST(FastCDRTests, STDArrayInt8)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << int8_array_t;
-    });
+        {
+            cdr_ser << int8_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3256,9 +3270,9 @@ TEST(FastCDRTests, STDArrayInt8)
     std::array<int8_t, N_ARR_ELEMENTS> int8_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> int8_array_value;
-    });
+        {
+            cdr_des >> int8_array_value;
+        });
 
     EXPECT_EQ(int8_array_value, int8_array_t);
 
@@ -3270,18 +3284,18 @@ TEST(FastCDRTests, STDArrayInt8)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << int8_array_t;
-    },
+        {
+            cdr_ser_bad << int8_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> int8_array_value;
-    },
+        {
+            cdr_des_bad >> int8_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3295,9 +3309,9 @@ TEST(FastCDRTests, STDArrayUnsignedShort)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << ushort_array_t;
-    });
+        {
+            cdr_ser << ushort_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3305,9 +3319,9 @@ TEST(FastCDRTests, STDArrayUnsignedShort)
     std::array<uint16_t, N_ARR_ELEMENTS> ushort_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> ushort_array_value;
-    });
+        {
+            cdr_des >> ushort_array_value;
+        });
 
     EXPECT_EQ(ushort_array_value, ushort_array_t);
 
@@ -3319,18 +3333,18 @@ TEST(FastCDRTests, STDArrayUnsignedShort)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << ushort_array_t;
-    },
+        {
+            cdr_ser_bad << ushort_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> ushort_array_value;
-    },
+        {
+            cdr_des_bad >> ushort_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3344,9 +3358,9 @@ TEST(FastCDRTests, STDArrayShort)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << short_array_t;
-    });
+        {
+            cdr_ser << short_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3354,9 +3368,9 @@ TEST(FastCDRTests, STDArrayShort)
     std::array<int16_t, N_ARR_ELEMENTS> short_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> short_array_value;
-    });
+        {
+            cdr_des >> short_array_value;
+        });
 
     EXPECT_EQ(short_array_value, short_array_t);
 
@@ -3368,18 +3382,18 @@ TEST(FastCDRTests, STDArrayShort)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << short_array_t;
-    },
+        {
+            cdr_ser_bad << short_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> short_array_value;
-    },
+        {
+            cdr_des_bad >> short_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3393,9 +3407,9 @@ TEST(FastCDRTests, STDArrayUnsignedLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << ulong_array_t;
-    });
+        {
+            cdr_ser << ulong_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3403,9 +3417,9 @@ TEST(FastCDRTests, STDArrayUnsignedLong)
     std::array<uint32_t, N_ARR_ELEMENTS> ulong_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> ulong_array_value;
-    });
+        {
+            cdr_des >> ulong_array_value;
+        });
 
     EXPECT_EQ(ulong_array_value, ulong_array_t);
 
@@ -3417,18 +3431,18 @@ TEST(FastCDRTests, STDArrayUnsignedLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << ulong_array_t;
-    },
+        {
+            cdr_ser_bad << ulong_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> ulong_array_value;
-    },
+        {
+            cdr_des_bad >> ulong_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3442,9 +3456,9 @@ TEST(FastCDRTests, STDArrayLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << long_array_t;
-    });
+        {
+            cdr_ser << long_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3452,9 +3466,9 @@ TEST(FastCDRTests, STDArrayLong)
     std::array<int32_t, N_ARR_ELEMENTS> long_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> long_array_value;
-    });
+        {
+            cdr_des >> long_array_value;
+        });
 
     EXPECT_EQ(long_array_value, long_array_t);
 
@@ -3466,18 +3480,18 @@ TEST(FastCDRTests, STDArrayLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << long_array_t;
-    },
+        {
+            cdr_ser_bad << long_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> long_array_value;
-    },
+        {
+            cdr_des_bad >> long_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3491,9 +3505,9 @@ TEST(FastCDRTests, STDArrayUnsignedLongLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << ulonglong_array_t;
-    });
+        {
+            cdr_ser << ulonglong_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3501,9 +3515,9 @@ TEST(FastCDRTests, STDArrayUnsignedLongLong)
     std::array<uint64_t, N_ARR_ELEMENTS> ulonglong_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> ulonglong_array_value;
-    });
+        {
+            cdr_des >> ulonglong_array_value;
+        });
 
     EXPECT_EQ(ulonglong_array_value, ulonglong_array_t);
 
@@ -3515,18 +3529,18 @@ TEST(FastCDRTests, STDArrayUnsignedLongLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << ulonglong_array_t;
-    },
+        {
+            cdr_ser_bad << ulonglong_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> ulonglong_array_value;
-    },
+        {
+            cdr_des_bad >> ulonglong_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3540,9 +3554,9 @@ TEST(FastCDRTests, STDArrayLongLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << longlong_array_t;
-    });
+        {
+            cdr_ser << longlong_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3550,9 +3564,9 @@ TEST(FastCDRTests, STDArrayLongLong)
     std::array<int64_t, N_ARR_ELEMENTS> longlong_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> longlong_array_value;
-    });
+        {
+            cdr_des >> longlong_array_value;
+        });
 
     EXPECT_EQ(longlong_array_value, longlong_array_t);
 
@@ -3564,18 +3578,18 @@ TEST(FastCDRTests, STDArrayLongLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << longlong_array_t;
-    },
+        {
+            cdr_ser_bad << longlong_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> longlong_array_value;
-    },
+        {
+            cdr_des_bad >> longlong_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3589,9 +3603,9 @@ TEST(FastCDRTests, STDArrayFloat)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << float_array_t;
-    });
+        {
+            cdr_ser << float_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3599,9 +3613,9 @@ TEST(FastCDRTests, STDArrayFloat)
     std::array<float, N_ARR_ELEMENTS> float_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> float_array_value;
-    });
+        {
+            cdr_des >> float_array_value;
+        });
 
     EXPECT_EQ(float_array_value, float_array_t);
 
@@ -3613,18 +3627,18 @@ TEST(FastCDRTests, STDArrayFloat)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << float_array_t;
-    },
+        {
+            cdr_ser_bad << float_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> float_array_value;
-    },
+        {
+            cdr_des_bad >> float_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3638,9 +3652,9 @@ TEST(FastCDRTests, STDArrayDouble)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << double_array_t;
-    });
+        {
+            cdr_ser << double_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3648,9 +3662,9 @@ TEST(FastCDRTests, STDArrayDouble)
     std::array<double, N_ARR_ELEMENTS> double_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> double_array_value;
-    });
+        {
+            cdr_des >> double_array_value;
+        });
 
     EXPECT_EQ(double_array_value, double_array_t);
 
@@ -3662,18 +3676,18 @@ TEST(FastCDRTests, STDArrayDouble)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << double_array_t;
-    },
+        {
+            cdr_ser_bad << double_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> double_array_value;
-    },
+        {
+            cdr_des_bad >> double_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3687,9 +3701,9 @@ TEST(FastCDRTests, STDArrayLongDouble)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << ldouble_array_t;
-    });
+        {
+            cdr_ser << ldouble_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3697,9 +3711,9 @@ TEST(FastCDRTests, STDArrayLongDouble)
     std::array<long double, N_ARR_ELEMENTS> ldouble_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> ldouble_array_value;
-    });
+        {
+            cdr_des >> ldouble_array_value;
+        });
 
     EXPECT_EQ(ldouble_array_value, ldouble_array_t);
 
@@ -3711,18 +3725,18 @@ TEST(FastCDRTests, STDArrayLongDouble)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << ldouble_array_t;
-    },
+        {
+            cdr_ser_bad << ldouble_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> ldouble_array_value;
-    },
+        {
+            cdr_des_bad >> ldouble_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3736,9 +3750,9 @@ TEST(FastCDRTests, STDArrayBoolean)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << bool_array_t;
-    });
+        {
+            cdr_ser << bool_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3746,9 +3760,9 @@ TEST(FastCDRTests, STDArrayBoolean)
     std::array<bool, N_ARR_ELEMENTS> bool_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> bool_array_value;
-    });
+        {
+            cdr_des >> bool_array_value;
+        });
 
     EXPECT_EQ(bool_array_value, bool_array_t);
 
@@ -3760,18 +3774,18 @@ TEST(FastCDRTests, STDArrayBoolean)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << bool_array_t;
-    },
+        {
+            cdr_ser_bad << bool_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> bool_array_value;
-    },
+        {
+            cdr_des_bad >> bool_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3785,9 +3799,9 @@ TEST(FastCDRTests, STDArrayString)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << string_array_t;
-    });
+        {
+            cdr_ser << string_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3795,9 +3809,9 @@ TEST(FastCDRTests, STDArrayString)
     std::array<std::string, N_ARR_ELEMENTS> string_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> string_array_value;
-    });
+        {
+            cdr_des >> string_array_value;
+        });
 
     EXPECT_EQ(string_array_value, string_array_t);
 
@@ -3809,18 +3823,18 @@ TEST(FastCDRTests, STDArrayString)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << string_array_t;
-    },
+        {
+            cdr_ser_bad << string_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> string_array_value;
-    },
+        {
+            cdr_des_bad >> string_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3834,9 +3848,9 @@ TEST(FastCDRTests, STDArrayWString)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << wstring_array_t;
-    });
+        {
+            cdr_ser << wstring_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3844,9 +3858,9 @@ TEST(FastCDRTests, STDArrayWString)
     std::array<std::wstring, N_ARR_ELEMENTS> string_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> string_array_value;
-    });
+        {
+            cdr_des >> string_array_value;
+        });
 
     EXPECT_EQ(string_array_value, wstring_array_t);
 
@@ -3858,18 +3872,18 @@ TEST(FastCDRTests, STDArrayWString)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << wstring_array_t;
-    },
+        {
+            cdr_ser_bad << wstring_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> string_array_value;
-    },
+        {
+            cdr_des_bad >> string_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -3883,9 +3897,9 @@ TEST(FastCDRTests, ArrayOctet)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_array(octet_array_2_t, 5);
-    });
+        {
+            cdr_ser.serialize_array(octet_array_2_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3893,9 +3907,9 @@ TEST(FastCDRTests, ArrayOctet)
     uint8_t octet_array_2_value[N_ARR_ELEMENTS];
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_array(octet_array_2_value, 5);
-    });
+        {
+            cdr_des.deserialize_array(octet_array_2_value, 5);
+        });
 
     EXPECT_ARRAY_EQ(octet_array_2_value, octet_array_2_t, 5);
 
@@ -3907,18 +3921,18 @@ TEST(FastCDRTests, ArrayOctet)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_array(octet_array_2_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_array(octet_array_2_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_array(octet_array_2_value, 5);
-    },
+        {
+            cdr_des_bad.deserialize_array(octet_array_2_value, 5);
+        },
         NotEnoughMemoryException);
 }
 
@@ -3932,9 +3946,9 @@ TEST(FastCDRTests, ArrayChar)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_array(char_array_2_t, 5);
-    });
+        {
+            cdr_ser.serialize_array(char_array_2_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3942,9 +3956,9 @@ TEST(FastCDRTests, ArrayChar)
     char char_array_2_value[N_ARR_ELEMENTS];
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_array(char_array_2_value, 5);
-    });
+        {
+            cdr_des.deserialize_array(char_array_2_value, 5);
+        });
 
     EXPECT_ARRAY_EQ(char_array_2_value, char_array_2_t, 5);
 
@@ -3956,18 +3970,18 @@ TEST(FastCDRTests, ArrayChar)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_array(char_array_2_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_array(char_array_2_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_array(char_array_2_value, 5);
-    },
+        {
+            cdr_des_bad.deserialize_array(char_array_2_value, 5);
+        },
         NotEnoughMemoryException);
 }
 
@@ -3981,9 +3995,9 @@ TEST(FastCDRTests, ArrayWChar)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_array(wchar_array_2_t, 5);
-    });
+        {
+            cdr_ser.serialize_array(wchar_array_2_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -3991,9 +4005,9 @@ TEST(FastCDRTests, ArrayWChar)
     wchar_t char_array_2_value[N_ARR_ELEMENTS];
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_array(char_array_2_value, 5);
-    });
+        {
+            cdr_des.deserialize_array(char_array_2_value, 5);
+        });
 
     EXPECT_ARRAY_EQ(char_array_2_value, wchar_array_2_t, 5);
 
@@ -4005,18 +4019,18 @@ TEST(FastCDRTests, ArrayWChar)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_array(wchar_array_2_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_array(wchar_array_2_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_array(char_array_2_value, 5);
-    },
+        {
+            cdr_des_bad.deserialize_array(char_array_2_value, 5);
+        },
         NotEnoughMemoryException);
 }
 
@@ -4030,9 +4044,9 @@ TEST(FastCDRTests, ArrayInt8)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_array(int8_array_2_t, 5);
-    });
+        {
+            cdr_ser.serialize_array(int8_array_2_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4040,9 +4054,9 @@ TEST(FastCDRTests, ArrayInt8)
     int8_t int8_array_2_value[N_ARR_ELEMENTS];
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_array(int8_array_2_value, 5);
-    });
+        {
+            cdr_des.deserialize_array(int8_array_2_value, 5);
+        });
 
     EXPECT_ARRAY_EQ(int8_array_2_value, int8_array_2_t, 5);
 
@@ -4054,18 +4068,18 @@ TEST(FastCDRTests, ArrayInt8)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_array(int8_array_2_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_array(int8_array_2_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_array(int8_array_2_value, 5);
-    },
+        {
+            cdr_des_bad.deserialize_array(int8_array_2_value, 5);
+        },
         NotEnoughMemoryException);
 }
 
@@ -4079,9 +4093,9 @@ TEST(FastCDRTests, ArrayUnsignedShort)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_array(ushort_array_2_t, 5);
-    });
+        {
+            cdr_ser.serialize_array(ushort_array_2_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4089,9 +4103,9 @@ TEST(FastCDRTests, ArrayUnsignedShort)
     uint16_t ushort_array_2_value[N_ARR_ELEMENTS];
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_array(ushort_array_2_value, 5);
-    });
+        {
+            cdr_des.deserialize_array(ushort_array_2_value, 5);
+        });
 
     EXPECT_ARRAY_EQ(ushort_array_2_value, ushort_array_2_t, 5);
 
@@ -4103,18 +4117,18 @@ TEST(FastCDRTests, ArrayUnsignedShort)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_array(ushort_array_2_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_array(ushort_array_2_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_array(ushort_array_2_value, 5);
-    },
+        {
+            cdr_des_bad.deserialize_array(ushort_array_2_value, 5);
+        },
         NotEnoughMemoryException);
 }
 
@@ -4128,9 +4142,9 @@ TEST(FastCDRTests, ArrayShort)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_array(short_array_2_t, 5);
-    });
+        {
+            cdr_ser.serialize_array(short_array_2_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4138,9 +4152,9 @@ TEST(FastCDRTests, ArrayShort)
     int16_t short_array_2_value[N_ARR_ELEMENTS];
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_array(short_array_2_value, 5);
-    });
+        {
+            cdr_des.deserialize_array(short_array_2_value, 5);
+        });
 
     EXPECT_ARRAY_EQ(short_array_2_value, short_array_2_t, 5);
 
@@ -4152,18 +4166,18 @@ TEST(FastCDRTests, ArrayShort)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_array(short_array_2_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_array(short_array_2_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_array(short_array_2_value, 5);
-    },
+        {
+            cdr_des_bad.deserialize_array(short_array_2_value, 5);
+        },
         NotEnoughMemoryException);
 }
 
@@ -4177,9 +4191,9 @@ TEST(FastCDRTests, ArrayUnsignedLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_array(ulong_array_2_t, 5);
-    });
+        {
+            cdr_ser.serialize_array(ulong_array_2_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4187,9 +4201,9 @@ TEST(FastCDRTests, ArrayUnsignedLong)
     uint32_t ulong_array_2_value[N_ARR_ELEMENTS];
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_array(ulong_array_2_value, 5);
-    });
+        {
+            cdr_des.deserialize_array(ulong_array_2_value, 5);
+        });
 
     EXPECT_ARRAY_EQ(ulong_array_2_value, ulong_array_2_t, 5);
 
@@ -4201,18 +4215,18 @@ TEST(FastCDRTests, ArrayUnsignedLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_array(ulong_array_2_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_array(ulong_array_2_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_array(ulong_array_2_value, 5);
-    },
+        {
+            cdr_des_bad.deserialize_array(ulong_array_2_value, 5);
+        },
         NotEnoughMemoryException);
 }
 
@@ -4226,9 +4240,9 @@ TEST(FastCDRTests, ArrayLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_array(long_array_2_t, 5);
-    });
+        {
+            cdr_ser.serialize_array(long_array_2_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4236,9 +4250,9 @@ TEST(FastCDRTests, ArrayLong)
     int32_t long_array_2_value[N_ARR_ELEMENTS];
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_array(long_array_2_value, 5);
-    });
+        {
+            cdr_des.deserialize_array(long_array_2_value, 5);
+        });
 
     EXPECT_ARRAY_EQ(long_array_2_value, long_array_2_t, 5);
 
@@ -4250,18 +4264,18 @@ TEST(FastCDRTests, ArrayLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_array(long_array_2_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_array(long_array_2_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_array(long_array_2_value, 5);
-    },
+        {
+            cdr_des_bad.deserialize_array(long_array_2_value, 5);
+        },
         NotEnoughMemoryException);
 }
 
@@ -4275,9 +4289,9 @@ TEST(FastCDRTests, ArrayUnsignedLongLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_array(ulonglong_array_2_t, 5);
-    });
+        {
+            cdr_ser.serialize_array(ulonglong_array_2_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4285,9 +4299,9 @@ TEST(FastCDRTests, ArrayUnsignedLongLong)
     uint64_t ulonglong_array_2_value[N_ARR_ELEMENTS];
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_array(ulonglong_array_2_value, 5);
-    });
+        {
+            cdr_des.deserialize_array(ulonglong_array_2_value, 5);
+        });
 
     EXPECT_ARRAY_EQ(ulonglong_array_2_value, ulonglong_array_2_t, 5);
 
@@ -4299,18 +4313,18 @@ TEST(FastCDRTests, ArrayUnsignedLongLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_array(ulonglong_array_2_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_array(ulonglong_array_2_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_array(ulonglong_array_2_value, 5);
-    },
+        {
+            cdr_des_bad.deserialize_array(ulonglong_array_2_value, 5);
+        },
         NotEnoughMemoryException);
 }
 
@@ -4324,9 +4338,9 @@ TEST(FastCDRTests, ArrayLongLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_array(longlong_array_2_t, 5);
-    });
+        {
+            cdr_ser.serialize_array(longlong_array_2_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4334,9 +4348,9 @@ TEST(FastCDRTests, ArrayLongLong)
     int64_t longlong_array_2_value[N_ARR_ELEMENTS];
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_array(longlong_array_2_value, 5);
-    });
+        {
+            cdr_des.deserialize_array(longlong_array_2_value, 5);
+        });
 
     EXPECT_ARRAY_EQ(longlong_array_2_value, longlong_array_2_t, 5);
 
@@ -4348,18 +4362,18 @@ TEST(FastCDRTests, ArrayLongLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_array(longlong_array_2_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_array(longlong_array_2_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_array(longlong_array_2_value, 5);
-    },
+        {
+            cdr_des_bad.deserialize_array(longlong_array_2_value, 5);
+        },
         NotEnoughMemoryException);
 }
 
@@ -4373,9 +4387,9 @@ TEST(FastCDRTests, ArrayFloat)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_array(float_array_2_t, 5);
-    });
+        {
+            cdr_ser.serialize_array(float_array_2_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4383,9 +4397,9 @@ TEST(FastCDRTests, ArrayFloat)
     float float_array_2_value[N_ARR_ELEMENTS];
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_array(float_array_2_value, 5);
-    });
+        {
+            cdr_des.deserialize_array(float_array_2_value, 5);
+        });
 
     EXPECT_ARRAY_FLOAT_EQ(float_array_2_value, float_array_2_t, 5);
 
@@ -4397,18 +4411,18 @@ TEST(FastCDRTests, ArrayFloat)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_array(float_array_2_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_array(float_array_2_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_array(float_array_2_value, 5);
-    },
+        {
+            cdr_des_bad.deserialize_array(float_array_2_value, 5);
+        },
         NotEnoughMemoryException);
 }
 
@@ -4422,9 +4436,9 @@ TEST(FastCDRTests, ArrayDouble)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_array(double_array_2_t, 5);
-    });
+        {
+            cdr_ser.serialize_array(double_array_2_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4432,9 +4446,9 @@ TEST(FastCDRTests, ArrayDouble)
     double double_array_2_value[N_ARR_ELEMENTS];
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_array(double_array_2_value, 5);
-    });
+        {
+            cdr_des.deserialize_array(double_array_2_value, 5);
+        });
 
     EXPECT_ARRAY_DOUBLE_EQ(double_array_2_value, double_array_2_t, 5);
 
@@ -4446,18 +4460,18 @@ TEST(FastCDRTests, ArrayDouble)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_array(double_array_2_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_array(double_array_2_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_array(double_array_2_value, 5);
-    },
+        {
+            cdr_des_bad.deserialize_array(double_array_2_value, 5);
+        },
         NotEnoughMemoryException);
 }
 
@@ -4471,9 +4485,9 @@ TEST(FastCDRTests, ArrayLongDouble)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_array(ldouble_array_2_t, 5);
-    });
+        {
+            cdr_ser.serialize_array(ldouble_array_2_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4481,9 +4495,9 @@ TEST(FastCDRTests, ArrayLongDouble)
     long double ldouble_array_2_value[N_ARR_ELEMENTS];
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_array(ldouble_array_2_value, 5);
-    });
+        {
+            cdr_des.deserialize_array(ldouble_array_2_value, 5);
+        });
 
     EXPECT_ARRAY_LONG_DOUBLE_EQ(ldouble_array_2_value, ldouble_array_2_t, 5);
 
@@ -4495,18 +4509,18 @@ TEST(FastCDRTests, ArrayLongDouble)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_array(ldouble_array_2_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_array(ldouble_array_2_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_array(ldouble_array_2_value, 5);
-    },
+        {
+            cdr_des_bad.deserialize_array(ldouble_array_2_value, 5);
+        },
         NotEnoughMemoryException);
 }
 
@@ -4520,9 +4534,9 @@ TEST(FastCDRTests, ArrayBoolean)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_array(bool_array_2_t, 5);
-    });
+        {
+            cdr_ser.serialize_array(bool_array_2_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4530,9 +4544,9 @@ TEST(FastCDRTests, ArrayBoolean)
     bool bool_array_2_value[N_ARR_ELEMENTS];
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_array(bool_array_2_value, 5);
-    });
+        {
+            cdr_des.deserialize_array(bool_array_2_value, 5);
+        });
 
     EXPECT_ARRAY_EQ(bool_array_2_value, bool_array_2_t, 5);
 
@@ -4544,18 +4558,18 @@ TEST(FastCDRTests, ArrayBoolean)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_array(bool_array_2_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_array(bool_array_2_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_array(bool_array_2_value, 5);
-    },
+        {
+            cdr_des_bad.deserialize_array(bool_array_2_value, 5);
+        },
         NotEnoughMemoryException);
 }
 
@@ -4569,9 +4583,9 @@ TEST(FastCDRTests, ArrayString)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_array(string_array_2_t, 5);
-    });
+        {
+            cdr_ser.serialize_array(string_array_2_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4579,9 +4593,9 @@ TEST(FastCDRTests, ArrayString)
     std::string string_array_2_value[N_ARR_ELEMENTS];
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_array(string_array_2_value, 5);
-    });
+        {
+            cdr_des.deserialize_array(string_array_2_value, 5);
+        });
 
     EXPECT_ARRAY_EQ(string_array_2_value, string_array_2_t, 5);
 
@@ -4593,18 +4607,18 @@ TEST(FastCDRTests, ArrayString)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_array(string_array_2_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_array(string_array_2_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_array(string_array_2_value, 5);
-    },
+        {
+            cdr_des_bad.deserialize_array(string_array_2_value, 5);
+        },
         NotEnoughMemoryException);
 }
 
@@ -4618,9 +4632,9 @@ TEST(FastCDRTests, ArrayWString)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_array(wstring_array_2_t, 5);
-    });
+        {
+            cdr_ser.serialize_array(wstring_array_2_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4628,9 +4642,9 @@ TEST(FastCDRTests, ArrayWString)
     std::wstring string_array_2_value[N_ARR_ELEMENTS];
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_array(string_array_2_value, 5);
-    });
+        {
+            cdr_des.deserialize_array(string_array_2_value, 5);
+        });
 
     EXPECT_ARRAY_EQ(string_array_2_value, wstring_array_2_t, 5);
 
@@ -4642,18 +4656,18 @@ TEST(FastCDRTests, ArrayWString)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_array(wstring_array_2_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_array(wstring_array_2_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_array(string_array_2_value, 5);
-    },
+        {
+            cdr_des_bad.deserialize_array(string_array_2_value, 5);
+        },
         NotEnoughMemoryException);
 }
 
@@ -4667,9 +4681,9 @@ TEST(FastCDRTests, STDVectorOctet)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << octet_vector_t;
-    });
+        {
+            cdr_ser << octet_vector_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4677,9 +4691,9 @@ TEST(FastCDRTests, STDVectorOctet)
     std::vector<uint8_t> octet_vector_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> octet_vector_value;
-    });
+        {
+            cdr_des >> octet_vector_value;
+        });
 
     EXPECT_EQ(octet_vector_value, octet_vector_t);
 
@@ -4691,18 +4705,18 @@ TEST(FastCDRTests, STDVectorOctet)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << octet_vector_t;
-    },
+        {
+            cdr_ser_bad << octet_vector_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> octet_vector_value;
-    },
+        {
+            cdr_des_bad >> octet_vector_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -4716,9 +4730,9 @@ TEST(FastCDRTests, STDVectorChar)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << char_vector_t;
-    });
+        {
+            cdr_ser << char_vector_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4726,9 +4740,9 @@ TEST(FastCDRTests, STDVectorChar)
     std::vector<char> char_vector_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> char_vector_value;
-    });
+        {
+            cdr_des >> char_vector_value;
+        });
 
     EXPECT_EQ(char_vector_value, char_vector_t);
 
@@ -4740,18 +4754,18 @@ TEST(FastCDRTests, STDVectorChar)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << char_vector_t;
-    },
+        {
+            cdr_ser_bad << char_vector_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> char_vector_value;
-    },
+        {
+            cdr_des_bad >> char_vector_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -4765,9 +4779,9 @@ TEST(FastCDRTests, STDVectorWChar)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << wchar_vector_t;
-    });
+        {
+            cdr_ser << wchar_vector_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4775,9 +4789,9 @@ TEST(FastCDRTests, STDVectorWChar)
     std::vector<wchar_t> char_vector_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> char_vector_value;
-    });
+        {
+            cdr_des >> char_vector_value;
+        });
 
     EXPECT_EQ(char_vector_value, wchar_vector_t);
 
@@ -4789,18 +4803,18 @@ TEST(FastCDRTests, STDVectorWChar)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << wchar_vector_t;
-    },
+        {
+            cdr_ser_bad << wchar_vector_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> char_vector_value;
-    },
+        {
+            cdr_des_bad >> char_vector_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -4814,9 +4828,9 @@ TEST(FastCDRTests, STDVectorInt8)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << int8_vector_t;
-    });
+        {
+            cdr_ser << int8_vector_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4824,9 +4838,9 @@ TEST(FastCDRTests, STDVectorInt8)
     std::vector<int8_t> int8_vector_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> int8_vector_value;
-    });
+        {
+            cdr_des >> int8_vector_value;
+        });
 
     EXPECT_EQ(int8_vector_value, int8_vector_t);
 
@@ -4838,18 +4852,18 @@ TEST(FastCDRTests, STDVectorInt8)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << int8_vector_t;
-    },
+        {
+            cdr_ser_bad << int8_vector_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> int8_vector_value;
-    },
+        {
+            cdr_des_bad >> int8_vector_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -4863,9 +4877,9 @@ TEST(FastCDRTests, STDVectorUnsignedShort)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << ushort_vector_t;
-    });
+        {
+            cdr_ser << ushort_vector_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4873,9 +4887,9 @@ TEST(FastCDRTests, STDVectorUnsignedShort)
     std::vector<uint16_t> ushort_vector_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> ushort_vector_value;
-    });
+        {
+            cdr_des >> ushort_vector_value;
+        });
 
     EXPECT_EQ(ushort_vector_value, ushort_vector_t);
 
@@ -4887,18 +4901,18 @@ TEST(FastCDRTests, STDVectorUnsignedShort)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << ushort_vector_t;
-    },
+        {
+            cdr_ser_bad << ushort_vector_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> ushort_vector_value;
-    },
+        {
+            cdr_des_bad >> ushort_vector_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -4912,9 +4926,9 @@ TEST(FastCDRTests, STDVectorShort)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << short_vector_t;
-    });
+        {
+            cdr_ser << short_vector_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4922,9 +4936,9 @@ TEST(FastCDRTests, STDVectorShort)
     std::vector<int16_t> short_vector_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> short_vector_value;
-    });
+        {
+            cdr_des >> short_vector_value;
+        });
 
     EXPECT_EQ(short_vector_value, short_vector_t);
 
@@ -4936,18 +4950,18 @@ TEST(FastCDRTests, STDVectorShort)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << short_vector_t;
-    },
+        {
+            cdr_ser_bad << short_vector_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> short_vector_value;
-    },
+        {
+            cdr_des_bad >> short_vector_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -4961,9 +4975,9 @@ TEST(FastCDRTests, STDVectorUnsignedLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << ulong_vector_t;
-    });
+        {
+            cdr_ser << ulong_vector_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -4971,9 +4985,9 @@ TEST(FastCDRTests, STDVectorUnsignedLong)
     std::vector<uint32_t> ulong_vector_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> ulong_vector_value;
-    });
+        {
+            cdr_des >> ulong_vector_value;
+        });
 
     EXPECT_EQ(ulong_vector_value, ulong_vector_t);
 
@@ -4985,18 +4999,18 @@ TEST(FastCDRTests, STDVectorUnsignedLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << ulong_vector_t;
-    },
+        {
+            cdr_ser_bad << ulong_vector_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> ulong_vector_value;
-    },
+        {
+            cdr_des_bad >> ulong_vector_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -5010,9 +5024,9 @@ TEST(FastCDRTests, STDVectorLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << long_vector_t;
-    });
+        {
+            cdr_ser << long_vector_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5020,9 +5034,9 @@ TEST(FastCDRTests, STDVectorLong)
     std::vector<int32_t> long_vector_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> long_vector_value;
-    });
+        {
+            cdr_des >> long_vector_value;
+        });
 
     EXPECT_EQ(long_vector_value, long_vector_t);
 
@@ -5034,18 +5048,18 @@ TEST(FastCDRTests, STDVectorLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << long_vector_t;
-    },
+        {
+            cdr_ser_bad << long_vector_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> long_vector_value;
-    },
+        {
+            cdr_des_bad >> long_vector_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -5059,9 +5073,9 @@ TEST(FastCDRTests, STDVectorUnsignedLongLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << ulonglong_vector_t;
-    });
+        {
+            cdr_ser << ulonglong_vector_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5069,9 +5083,9 @@ TEST(FastCDRTests, STDVectorUnsignedLongLong)
     std::vector<uint64_t> ulonglong_vector_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> ulonglong_vector_value;
-    });
+        {
+            cdr_des >> ulonglong_vector_value;
+        });
 
     EXPECT_EQ(ulonglong_vector_value, ulonglong_vector_t);
 
@@ -5083,18 +5097,18 @@ TEST(FastCDRTests, STDVectorUnsignedLongLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << ulonglong_vector_t;
-    },
+        {
+            cdr_ser_bad << ulonglong_vector_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> ulonglong_vector_value;
-    },
+        {
+            cdr_des_bad >> ulonglong_vector_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -5108,9 +5122,9 @@ TEST(FastCDRTests, STDVectorLongLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << longlong_vector_t;
-    });
+        {
+            cdr_ser << longlong_vector_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5118,9 +5132,9 @@ TEST(FastCDRTests, STDVectorLongLong)
     std::vector<int64_t> longlong_vector_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> longlong_vector_value;
-    });
+        {
+            cdr_des >> longlong_vector_value;
+        });
 
     EXPECT_EQ(longlong_vector_value, longlong_vector_t);
 
@@ -5132,18 +5146,18 @@ TEST(FastCDRTests, STDVectorLongLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << longlong_vector_t;
-    },
+        {
+            cdr_ser_bad << longlong_vector_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> longlong_vector_value;
-    },
+        {
+            cdr_des_bad >> longlong_vector_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -5157,9 +5171,9 @@ TEST(FastCDRTests, STDVectorFloat)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << float_vector_t;
-    });
+        {
+            cdr_ser << float_vector_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5167,9 +5181,9 @@ TEST(FastCDRTests, STDVectorFloat)
     std::vector<float> float_vector_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> float_vector_value;
-    });
+        {
+            cdr_des >> float_vector_value;
+        });
 
     EXPECT_EQ(float_vector_value, float_vector_t);
 
@@ -5181,18 +5195,18 @@ TEST(FastCDRTests, STDVectorFloat)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << float_vector_t;
-    },
+        {
+            cdr_ser_bad << float_vector_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> float_vector_value;
-    },
+        {
+            cdr_des_bad >> float_vector_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -5206,9 +5220,9 @@ TEST(FastCDRTests, STDVectorDouble)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << double_vector_t;
-    });
+        {
+            cdr_ser << double_vector_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5216,9 +5230,9 @@ TEST(FastCDRTests, STDVectorDouble)
     std::vector<double> double_vector_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> double_vector_value;
-    });
+        {
+            cdr_des >> double_vector_value;
+        });
 
     EXPECT_EQ(double_vector_value, double_vector_t);
 
@@ -5230,18 +5244,18 @@ TEST(FastCDRTests, STDVectorDouble)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << double_vector_t;
-    },
+        {
+            cdr_ser_bad << double_vector_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> double_vector_value;
-    },
+        {
+            cdr_des_bad >> double_vector_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -5255,9 +5269,9 @@ TEST(FastCDRTests, STDVectorLongDouble)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << ldouble_vector_t;
-    });
+        {
+            cdr_ser << ldouble_vector_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5265,9 +5279,9 @@ TEST(FastCDRTests, STDVectorLongDouble)
     std::vector<long double> ldouble_vector_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> ldouble_vector_value;
-    });
+        {
+            cdr_des >> ldouble_vector_value;
+        });
 
     EXPECT_EQ(ldouble_vector_value, ldouble_vector_t);
 
@@ -5279,18 +5293,18 @@ TEST(FastCDRTests, STDVectorLongDouble)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << ldouble_vector_t;
-    },
+        {
+            cdr_ser_bad << ldouble_vector_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> ldouble_vector_value;
-    },
+        {
+            cdr_des_bad >> ldouble_vector_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -5304,9 +5318,9 @@ TEST(FastCDRTests, STDVectorBoolean)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << bool_vector_t;
-    });
+        {
+            cdr_ser << bool_vector_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5314,9 +5328,9 @@ TEST(FastCDRTests, STDVectorBoolean)
     std::vector<bool> bool_vector_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> bool_vector_value;
-    });
+        {
+            cdr_des >> bool_vector_value;
+        });
 
     EXPECT_EQ(bool_vector_value, bool_vector_t);
 
@@ -5328,18 +5342,18 @@ TEST(FastCDRTests, STDVectorBoolean)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << bool_vector_t;
-    },
+        {
+            cdr_ser_bad << bool_vector_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> bool_vector_value;
-    },
+        {
+            cdr_des_bad >> bool_vector_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -5353,9 +5367,9 @@ TEST(FastCDRTests, STDVectorString)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << string_vector_t;
-    });
+        {
+            cdr_ser << string_vector_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5363,9 +5377,9 @@ TEST(FastCDRTests, STDVectorString)
     std::vector<std::string> string_vector_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> string_vector_value;
-    });
+        {
+            cdr_des >> string_vector_value;
+        });
 
     EXPECT_EQ(string_vector_value, string_vector_t);
 
@@ -5377,18 +5391,18 @@ TEST(FastCDRTests, STDVectorString)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << string_vector_t;
-    },
+        {
+            cdr_ser_bad << string_vector_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> string_vector_value;
-    },
+        {
+            cdr_des_bad >> string_vector_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -5402,9 +5416,9 @@ TEST(FastCDRTests, STDVectorWString)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << wstring_vector_t;
-    });
+        {
+            cdr_ser << wstring_vector_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5412,9 +5426,9 @@ TEST(FastCDRTests, STDVectorWString)
     std::vector<std::wstring> string_vector_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> string_vector_value;
-    });
+        {
+            cdr_des >> string_vector_value;
+        });
 
     EXPECT_EQ(string_vector_value, wstring_vector_t);
 
@@ -5426,18 +5440,18 @@ TEST(FastCDRTests, STDVectorWString)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << wstring_vector_t;
-    },
+        {
+            cdr_ser_bad << wstring_vector_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> string_vector_value;
-    },
+        {
+            cdr_des_bad >> string_vector_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -5451,9 +5465,9 @@ TEST(FastCDRTests, STDTripleArrayUnsignedLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << triple_ulong_array_t;
-    });
+        {
+            cdr_ser << triple_ulong_array_t;
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5461,9 +5475,9 @@ TEST(FastCDRTests, STDTripleArrayUnsignedLong)
     std::array<std::array<std::array<uint32_t, 3>, 2>, 2> triple_ulong_array_value;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> triple_ulong_array_value;
-    });
+        {
+            cdr_des >> triple_ulong_array_value;
+        });
 
     EXPECT_EQ(triple_ulong_array_value, triple_ulong_array_t);
 
@@ -5475,18 +5489,18 @@ TEST(FastCDRTests, STDTripleArrayUnsignedLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad << triple_ulong_array_t;
-    },
+        {
+            cdr_ser_bad << triple_ulong_array_t;
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad >> triple_ulong_array_value;
-    },
+        {
+            cdr_des_bad >> triple_ulong_array_value;
+        },
         NotEnoughMemoryException);
 }
 
@@ -5500,9 +5514,9 @@ TEST(FastCDRTests, SequenceOctet)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(octet_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(octet_seq_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5510,9 +5524,9 @@ TEST(FastCDRTests, SequenceOctet)
     uint8_t* octet_seq_value = NULL; size_t octet_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(octet_seq_value, octet_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(octet_seq_value, octet_seq_len);
+        });
 
     EXPECT_EQ(octet_seq_len, 5u);
     EXPECT_ARRAY_EQ(octet_seq_value, octet_seq_t, octet_seq_len);
@@ -5527,18 +5541,18 @@ TEST(FastCDRTests, SequenceOctet)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(octet_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(octet_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(octet_seq_value, octet_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(octet_seq_value, octet_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -5552,9 +5566,9 @@ TEST(FastCDRTests, SequenceChar)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(char_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(char_seq_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5562,9 +5576,9 @@ TEST(FastCDRTests, SequenceChar)
     char* char_seq_value = NULL; size_t char_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(char_seq_value, char_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(char_seq_value, char_seq_len);
+        });
 
     EXPECT_EQ(char_seq_len, 5u);
     EXPECT_ARRAY_EQ(char_seq_value, char_seq_t, char_seq_len);
@@ -5579,18 +5593,18 @@ TEST(FastCDRTests, SequenceChar)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(char_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(char_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(char_seq_value, char_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(char_seq_value, char_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -5604,9 +5618,9 @@ TEST(FastCDRTests, SequenceWChar)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(wchar_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(wchar_seq_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5614,9 +5628,9 @@ TEST(FastCDRTests, SequenceWChar)
     wchar_t* char_seq_value = NULL; size_t char_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(char_seq_value, char_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(char_seq_value, char_seq_len);
+        });
 
     EXPECT_EQ(char_seq_len, 5u);
     EXPECT_ARRAY_EQ(char_seq_value, wchar_seq_t, char_seq_len);
@@ -5631,18 +5645,18 @@ TEST(FastCDRTests, SequenceWChar)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(wchar_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(wchar_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(char_seq_value, char_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(char_seq_value, char_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -5656,9 +5670,9 @@ TEST(FastCDRTests, SequenceInt8)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(int8_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(int8_seq_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5666,9 +5680,9 @@ TEST(FastCDRTests, SequenceInt8)
     int8_t* int8_seq_value = NULL; size_t int8_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(int8_seq_value, int8_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(int8_seq_value, int8_seq_len);
+        });
 
     EXPECT_EQ(int8_seq_len, 5u);
     EXPECT_ARRAY_EQ(int8_seq_value, int8_seq_t, int8_seq_len);
@@ -5683,18 +5697,18 @@ TEST(FastCDRTests, SequenceInt8)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(int8_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(int8_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(int8_seq_value, int8_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(int8_seq_value, int8_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -5708,9 +5722,9 @@ TEST(FastCDRTests, SequenceUnsignedShort)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(ushort_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(ushort_seq_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5718,9 +5732,9 @@ TEST(FastCDRTests, SequenceUnsignedShort)
     uint16_t* ushort_seq_value = NULL; size_t ushort_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(ushort_seq_value, ushort_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(ushort_seq_value, ushort_seq_len);
+        });
 
     EXPECT_EQ(ushort_seq_len, 5u);
     EXPECT_ARRAY_EQ(ushort_seq_value, ushort_seq_t, ushort_seq_len);
@@ -5735,18 +5749,18 @@ TEST(FastCDRTests, SequenceUnsignedShort)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(ushort_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(ushort_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(ushort_seq_value, ushort_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(ushort_seq_value, ushort_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -5760,9 +5774,9 @@ TEST(FastCDRTests, SequenceShort)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(short_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(short_seq_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5770,9 +5784,9 @@ TEST(FastCDRTests, SequenceShort)
     int16_t* short_seq_value = NULL; size_t short_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(short_seq_value, short_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(short_seq_value, short_seq_len);
+        });
 
     EXPECT_EQ(short_seq_len, 5u);
     EXPECT_ARRAY_EQ(short_seq_value, short_seq_t, short_seq_len);
@@ -5787,18 +5801,18 @@ TEST(FastCDRTests, SequenceShort)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(short_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(short_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(short_seq_value, short_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(short_seq_value, short_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -5812,9 +5826,9 @@ TEST(FastCDRTests, SequenceUnsignedLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(ulong_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(ulong_seq_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5822,9 +5836,9 @@ TEST(FastCDRTests, SequenceUnsignedLong)
     uint32_t* ulong_seq_value = NULL; size_t ulong_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(ulong_seq_value, ulong_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(ulong_seq_value, ulong_seq_len);
+        });
 
     EXPECT_EQ(ulong_seq_len, 5u);
     EXPECT_ARRAY_EQ(ulong_seq_value, ulong_seq_t, ulong_seq_len);
@@ -5839,18 +5853,18 @@ TEST(FastCDRTests, SequenceUnsignedLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(ulong_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(ulong_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(ulong_seq_value, ulong_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(ulong_seq_value, ulong_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -5864,9 +5878,9 @@ TEST(FastCDRTests, SequenceLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(long_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(long_seq_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5874,9 +5888,9 @@ TEST(FastCDRTests, SequenceLong)
     int32_t* long_seq_value = NULL; size_t long_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(long_seq_value, long_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(long_seq_value, long_seq_len);
+        });
 
     EXPECT_EQ(long_seq_len, 5u);
     EXPECT_ARRAY_EQ(long_seq_value, long_seq_t, long_seq_len);
@@ -5891,18 +5905,18 @@ TEST(FastCDRTests, SequenceLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(long_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(long_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(long_seq_value, long_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(long_seq_value, long_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -5916,9 +5930,9 @@ TEST(FastCDRTests, SequenceUnsignedLongLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(ulonglong_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(ulonglong_seq_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5926,9 +5940,9 @@ TEST(FastCDRTests, SequenceUnsignedLongLong)
     uint64_t* ulonglong_seq_value = NULL; size_t ulonglong_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(ulonglong_seq_value, ulonglong_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(ulonglong_seq_value, ulonglong_seq_len);
+        });
 
     EXPECT_EQ(ulonglong_seq_len, 5u);
     EXPECT_ARRAY_EQ(ulonglong_seq_value, ulonglong_seq_t, ulonglong_seq_len);
@@ -5943,18 +5957,18 @@ TEST(FastCDRTests, SequenceUnsignedLongLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(ulonglong_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(ulonglong_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(ulonglong_seq_value, ulonglong_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(ulonglong_seq_value, ulonglong_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -5968,9 +5982,9 @@ TEST(FastCDRTests, SequenceLongLong)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(longlong_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(longlong_seq_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -5978,9 +5992,9 @@ TEST(FastCDRTests, SequenceLongLong)
     int64_t* longlong_seq_value = NULL; size_t longlong_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(longlong_seq_value, longlong_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(longlong_seq_value, longlong_seq_len);
+        });
 
     EXPECT_EQ(longlong_seq_len, 5u);
     EXPECT_ARRAY_EQ(longlong_seq_value, longlong_seq_t, longlong_seq_len);
@@ -5995,18 +6009,18 @@ TEST(FastCDRTests, SequenceLongLong)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(longlong_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(longlong_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(longlong_seq_value, longlong_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(longlong_seq_value, longlong_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -6020,9 +6034,9 @@ TEST(FastCDRTests, SequenceFloat)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(float_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(float_seq_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -6030,9 +6044,9 @@ TEST(FastCDRTests, SequenceFloat)
     float* float_seq_value = NULL; size_t float_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(float_seq_value, float_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(float_seq_value, float_seq_len);
+        });
 
     EXPECT_EQ(float_seq_len, 5u);
     EXPECT_ARRAY_FLOAT_EQ(float_seq_value, float_seq_t, float_seq_len);
@@ -6047,18 +6061,18 @@ TEST(FastCDRTests, SequenceFloat)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(float_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(float_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(float_seq_value, float_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(float_seq_value, float_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -6072,9 +6086,9 @@ TEST(FastCDRTests, SequenceDouble)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(double_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(double_seq_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -6082,9 +6096,9 @@ TEST(FastCDRTests, SequenceDouble)
     double* double_seq_value = NULL; size_t double_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(double_seq_value, double_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(double_seq_value, double_seq_len);
+        });
 
     EXPECT_EQ(double_seq_len, 5u);
     EXPECT_ARRAY_DOUBLE_EQ(double_seq_value, double_seq_t, double_seq_len);
@@ -6099,18 +6113,18 @@ TEST(FastCDRTests, SequenceDouble)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(double_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(double_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(double_seq_value, double_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(double_seq_value, double_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -6124,9 +6138,9 @@ TEST(FastCDRTests, SequenceLongDouble)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(ldouble_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(ldouble_seq_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -6134,9 +6148,9 @@ TEST(FastCDRTests, SequenceLongDouble)
     long double* ldouble_seq_value = NULL; size_t ldouble_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(ldouble_seq_value, ldouble_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(ldouble_seq_value, ldouble_seq_len);
+        });
 
     EXPECT_EQ(ldouble_seq_len, 5u);
     EXPECT_ARRAY_LONG_DOUBLE_EQ(ldouble_seq_value, ldouble_seq_t, ldouble_seq_len);
@@ -6151,18 +6165,18 @@ TEST(FastCDRTests, SequenceLongDouble)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(ldouble_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(ldouble_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(ldouble_seq_value, ldouble_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(ldouble_seq_value, ldouble_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -6176,9 +6190,9 @@ TEST(FastCDRTests, SequenceBoolean)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(bool_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(bool_seq_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -6186,9 +6200,9 @@ TEST(FastCDRTests, SequenceBoolean)
     bool* bool_seq_value = NULL; size_t bool_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(bool_seq_value, bool_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(bool_seq_value, bool_seq_len);
+        });
 
     EXPECT_EQ(bool_seq_len, 5u);
     EXPECT_ARRAY_EQ(bool_seq_value, bool_seq_t, bool_seq_len);
@@ -6203,18 +6217,18 @@ TEST(FastCDRTests, SequenceBoolean)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(bool_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(bool_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(bool_seq_value, bool_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(bool_seq_value, bool_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -6228,9 +6242,9 @@ TEST(FastCDRTests, SequenceString)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(string_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(string_seq_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -6238,9 +6252,9 @@ TEST(FastCDRTests, SequenceString)
     std::string* string_seq_value = NULL; size_t string_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(string_seq_value, string_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(string_seq_value, string_seq_len);
+        });
 
     EXPECT_EQ(string_seq_len, 5u);
     EXPECT_ARRAY_EQ(string_seq_value, string_seq_t, string_seq_len);
@@ -6255,18 +6269,18 @@ TEST(FastCDRTests, SequenceString)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(string_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(string_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(string_seq_value, string_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(string_seq_value, string_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -6280,9 +6294,9 @@ TEST(FastCDRTests, SequenceWString)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize_sequence(wstring_seq_t, 5);
-    });
+        {
+            cdr_ser.serialize_sequence(wstring_seq_t, 5);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -6290,9 +6304,9 @@ TEST(FastCDRTests, SequenceWString)
     std::wstring* string_seq_value = NULL; size_t string_seq_len = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize_sequence(string_seq_value, string_seq_len);
-    });
+        {
+            cdr_des.deserialize_sequence(string_seq_value, string_seq_len);
+        });
 
     EXPECT_EQ(string_seq_len, 5u);
     EXPECT_ARRAY_EQ(string_seq_value, wstring_seq_t, string_seq_len);
@@ -6307,18 +6321,18 @@ TEST(FastCDRTests, SequenceWString)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize_sequence(wstring_seq_t, 5);
-    },
+        {
+            cdr_ser_bad.serialize_sequence(wstring_seq_t, 5);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize_sequence(string_seq_value, string_seq_len);
-    },
+        {
+            cdr_des_bad.deserialize_sequence(string_seq_value, string_seq_len);
+        },
         NotEnoughMemoryException);
 }
 
@@ -6332,9 +6346,9 @@ TEST(FastCDRTests, CString)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize(c_string_t);
-    });
+        {
+            cdr_ser.serialize(c_string_t);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -6342,9 +6356,9 @@ TEST(FastCDRTests, CString)
     char* c_string_value = NULL;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize(c_string_value);
-    });
+        {
+            cdr_des.deserialize(c_string_value);
+        });
 
     EXPECT_EQ(strcmp(c_string_value, c_string_t), 0);
 
@@ -6358,18 +6372,18 @@ TEST(FastCDRTests, CString)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize(c_string_t);
-    },
+        {
+            cdr_ser_bad.serialize(c_string_t);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize(c_string_value);
-    },
+        {
+            cdr_des_bad.deserialize(c_string_value);
+        },
         NotEnoughMemoryException);
 }
 
@@ -6383,9 +6397,9 @@ TEST(FastCDRTests, CWString)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser.serialize(c_wstring_t);
-    });
+        {
+            cdr_ser.serialize(c_wstring_t);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -6393,9 +6407,9 @@ TEST(FastCDRTests, CWString)
     wchar_t* c_string_value = NULL;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des.deserialize(c_string_value);
-    });
+        {
+            cdr_des.deserialize(c_string_value);
+        });
 
     EXPECT_EQ(wcscmp(c_string_value, c_wstring_t), 0);
 
@@ -6409,18 +6423,18 @@ TEST(FastCDRTests, CWString)
     FastCdr cdr_ser_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_ser_bad.serialize(c_wstring_t);
-    },
+        {
+            cdr_ser_bad.serialize(c_wstring_t);
+        },
         NotEnoughMemoryException);
 
     // Deserialization.
     FastCdr cdr_des_bad(cdrbuffer_bad);
 
     EXPECT_THROW(
-    {
-        cdr_des_bad.deserialize(c_string_value);
-    },
+        {
+            cdr_des_bad.deserialize(c_string_value);
+        },
         NotEnoughMemoryException);
 }
 
@@ -6434,44 +6448,50 @@ TEST(FastCDRTests, Complete)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser << octet_t << char_t << int8 << ushort_t << short_t << ulong_t << long_t << ulonglong_t << longlong_t <<
-            float_tt << double_tt << ldouble_tt << bool_t << string_t;
-        cdr_ser << octet_array_t << char_array_t << int8_array_t << ushort_array_t << short_array_t << ulong_array_t <<
-            long_array_t << ulonglong_array_t << longlong_array_t << float_array_t << double_array_t << ldouble_array_t << bool_array_t;
-        cdr_ser.serialize_array(octet_array_2_t,
-        5).serialize_array(char_array_2_t, 5).serialize_array(int8_array_2_t, 5).
-                serialize_array(ushort_array_2_t, 5).serialize_array(short_array_2_t,
-        5).serialize_array(ulong_array_2_t,
-        5).
-                serialize_array(long_array_2_t, 5).serialize_array(ulonglong_array_2_t,
-        5).serialize_array(longlong_array_2_t, 5).
-                serialize_array(float_array_2_t, 5).serialize_array(double_array_2_t,
-        5).serialize_array(ldouble_array_2_t,
-        5).
-                serialize_array(bool_array_2_t,
-        5);
-        cdr_ser << octet_vector_t << char_vector_t << int8_vector_t << ushort_vector_t << short_vector_t << ulong_vector_t <<
-            long_vector_t << ulonglong_vector_t << longlong_vector_t << float_vector_t << double_vector_t <<
-            ldouble_vector_t << bool_vector_t;
-        cdr_ser << triple_ulong_array_t;
-        cdr_ser.serialize_sequence(octet_seq_t, 5).serialize_sequence(char_seq_t, 5).serialize_sequence(int8_seq_t, 5).
-                serialize_sequence(ushort_seq_t, 5).serialize_sequence(short_seq_t, 5).serialize_sequence(ulong_seq_t,
-        5).
-                serialize_sequence(long_seq_t, 5).serialize_sequence(ulonglong_seq_t,
-        5).serialize_sequence(longlong_seq_t,
-        5).
-                serialize_sequence(float_seq_t, 5).serialize_sequence(double_seq_t, 5).serialize_sequence(ldouble_seq_t,
-        5);
-        cdr_ser.serialize(c_string_t);
-        // Wstring and wchar
-        cdr_ser << wchar << wstring_t;
-        cdr_ser.serialize_array(wchar_array_2_t, 5).serialize_array(wstring_array_2_t, 5);
-        cdr_ser << wchar_array_t << wstring_array_t;
-        cdr_ser << wchar_vector_t << wstring_vector_t;
-        cdr_ser.serialize_sequence(wchar_seq_t, 5).serialize_sequence(wstring_seq_t, 5);
-        cdr_ser.serialize(c_wstring_t);
-    });
+        {
+            cdr_ser << octet_t << char_t << int8 << ushort_t << short_t << ulong_t << long_t << ulonglong_t
+                    << longlong_t
+                    << float_tt << double_tt << ldouble_tt << bool_t << string_t;
+            cdr_ser << octet_array_t << char_array_t << int8_array_t << ushort_array_t << short_array_t << ulong_array_t
+                    << long_array_t << ulonglong_array_t << longlong_array_t << float_array_t << double_array_t
+                    << ldouble_array_t << bool_array_t;
+            cdr_ser.serialize_array(octet_array_2_t,
+            5).serialize_array(char_array_2_t, 5).serialize_array(int8_array_2_t, 5).
+                    serialize_array(ushort_array_2_t, 5).serialize_array(short_array_2_t,
+            5).serialize_array(ulong_array_2_t,
+            5).
+                    serialize_array(long_array_2_t, 5).serialize_array(ulonglong_array_2_t,
+            5).serialize_array(longlong_array_2_t, 5).
+                    serialize_array(float_array_2_t, 5).serialize_array(double_array_2_t,
+            5).serialize_array(ldouble_array_2_t,
+            5).
+                    serialize_array(bool_array_2_t,
+            5);
+            cdr_ser << octet_vector_t << char_vector_t << int8_vector_t << ushort_vector_t << short_vector_t
+                    << ulong_vector_t
+                    << long_vector_t << ulonglong_vector_t << longlong_vector_t << float_vector_t << double_vector_t
+                    << ldouble_vector_t << bool_vector_t;
+            cdr_ser << triple_ulong_array_t;
+            cdr_ser.serialize_sequence(octet_seq_t, 5).serialize_sequence(char_seq_t, 5).serialize_sequence(int8_seq_t,
+            5).
+                    serialize_sequence(ushort_seq_t, 5).serialize_sequence(short_seq_t,
+            5).serialize_sequence(ulong_seq_t,
+            5).
+                    serialize_sequence(long_seq_t, 5).serialize_sequence(ulonglong_seq_t,
+            5).serialize_sequence(longlong_seq_t,
+            5).
+                    serialize_sequence(float_seq_t, 5).serialize_sequence(double_seq_t,
+            5).serialize_sequence(ldouble_seq_t,
+            5);
+            cdr_ser.serialize(c_string_t);
+            // Wstring and wchar
+            cdr_ser << wchar << wstring_t;
+            cdr_ser.serialize_array(wchar_array_2_t, 5).serialize_array(wstring_array_2_t, 5);
+            cdr_ser << wchar_array_t << wstring_array_t;
+            cdr_ser << wchar_vector_t << wstring_vector_t;
+            cdr_ser.serialize_sequence(wchar_seq_t, 5).serialize_sequence(wstring_seq_t, 5);
+            cdr_ser.serialize(c_wstring_t);
+        });
 
     // Deserialization.
     FastCdr cdr_des(cdrbuffer);
@@ -6556,46 +6576,53 @@ TEST(FastCDRTests, Complete)
     std::wstring* wstring_seq_value = NULL; size_t wstring_seq_len;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des >> octet_value >> char_value >> int8_value >> ushort_value >> short_value >> ulong_value >> long_value >>
-        ulonglong_value >> longlong_value >> float_value >> double_value >> ldouble_value >> bool_value >> string_value;
-        cdr_des >> octet_array_value >> char_array_value >> int8_array_value >> ushort_array_value >> short_array_value >>
-        ulong_array_value >> long_array_value >> ulonglong_array_value >> longlong_array_value >> float_array_value >>
-        double_array_value >> ldouble_array_value >> bool_array_value;
-        cdr_des.deserialize_array(octet_array_2_value,
-        5).deserialize_array(char_array_2_value, 5).deserialize_array(int8_array_2_value, 5).
-                deserialize_array(ushort_array_2_value, 5).deserialize_array(short_array_2_value,
-        5).deserialize_array(ulong_array_2_value, 5).
-                deserialize_array(long_array_2_value, 5).deserialize_array(ulonglong_array_2_value,
-        5).deserialize_array(longlong_array_2_value, 5).
-                deserialize_array(float_array_2_value, 5).deserialize_array(double_array_2_value,
-        5).deserialize_array(ldouble_array_2_value, 5).deserialize_array(bool_array_2_value,
-        5);
-        cdr_des >> octet_vector_value >> char_vector_value >> int8_vector_value >> ushort_vector_value >> short_vector_value >>
-        ulong_vector_value >> long_vector_value >> ulonglong_vector_value >> longlong_vector_value >> float_vector_value >>
-        double_vector_value >> ldouble_vector_value >> bool_vector_value;
-        cdr_des >> triple_ulong_array_value;
-        cdr_des.deserialize_sequence(octet_seq_value, octet_seq_len).deserialize_sequence(char_seq_value, char_seq_len).
-                deserialize_sequence(int8_seq_value, int8_seq_len).deserialize_sequence(ushort_seq_value,
-        ushort_seq_len).
-                deserialize_sequence(short_seq_value, short_seq_len).deserialize_sequence(ulong_seq_value,
-        ulong_seq_len).
-                deserialize_sequence(long_seq_value, long_seq_len).deserialize_sequence(ulonglong_seq_value,
-        ulonglong_seq_len).
-                deserialize_sequence(longlong_seq_value, longlong_seq_len).deserialize_sequence(float_seq_value,
-        float_seq_len).
-                deserialize_sequence(double_seq_value, double_seq_len).deserialize_sequence(ldouble_seq_value,
-        ldouble_seq_len);
-        cdr_des.deserialize(c_string_value);
-        // WString and wchar_t
-        cdr_des >> wchar_value >> wstring_value;
-        cdr_des.deserialize_array(wchar_array_2_value, 5).deserialize_array(wstring_array_2_value, 5);
-        cdr_des >> wchar_array_value >> wstring_array_value;
-        cdr_des >> wchar_vector_value >> wstring_vector_value;
-        cdr_des.deserialize_sequence(wchar_seq_value, wchar_seq_len).deserialize_sequence(wstring_seq_value,
-        wstring_seq_len);
-        cdr_des.deserialize(c_wstring_value);
-    });
+        {
+            cdr_des >> octet_value >> char_value >> int8_value >> ushort_value >> short_value >> ulong_value
+            >> long_value
+            >> ulonglong_value >> longlong_value >> float_value >> double_value >> ldouble_value >> bool_value
+            >> string_value;
+            cdr_des >> octet_array_value >> char_array_value >> int8_array_value >> ushort_array_value
+            >> short_array_value
+            >> ulong_array_value >> long_array_value >> ulonglong_array_value >> longlong_array_value
+            >> float_array_value
+            >> double_array_value >> ldouble_array_value >> bool_array_value;
+            cdr_des.deserialize_array(octet_array_2_value,
+            5).deserialize_array(char_array_2_value, 5).deserialize_array(int8_array_2_value, 5).
+                    deserialize_array(ushort_array_2_value, 5).deserialize_array(short_array_2_value,
+            5).deserialize_array(ulong_array_2_value, 5).
+                    deserialize_array(long_array_2_value, 5).deserialize_array(ulonglong_array_2_value,
+            5).deserialize_array(longlong_array_2_value, 5).
+                    deserialize_array(float_array_2_value, 5).deserialize_array(double_array_2_value,
+            5).deserialize_array(ldouble_array_2_value, 5).deserialize_array(bool_array_2_value,
+            5);
+            cdr_des >> octet_vector_value >> char_vector_value >> int8_vector_value >> ushort_vector_value
+            >> short_vector_value
+            >> ulong_vector_value >> long_vector_value >> ulonglong_vector_value >> longlong_vector_value
+            >> float_vector_value
+            >> double_vector_value >> ldouble_vector_value >> bool_vector_value;
+            cdr_des >> triple_ulong_array_value;
+            cdr_des.deserialize_sequence(octet_seq_value, octet_seq_len).deserialize_sequence(char_seq_value,
+            char_seq_len).
+                    deserialize_sequence(int8_seq_value, int8_seq_len).deserialize_sequence(ushort_seq_value,
+            ushort_seq_len).
+                    deserialize_sequence(short_seq_value, short_seq_len).deserialize_sequence(ulong_seq_value,
+            ulong_seq_len).
+                    deserialize_sequence(long_seq_value, long_seq_len).deserialize_sequence(ulonglong_seq_value,
+            ulonglong_seq_len).
+                    deserialize_sequence(longlong_seq_value, longlong_seq_len).deserialize_sequence(float_seq_value,
+            float_seq_len).
+                    deserialize_sequence(double_seq_value, double_seq_len).deserialize_sequence(ldouble_seq_value,
+            ldouble_seq_len);
+            cdr_des.deserialize(c_string_value);
+            // WString and wchar_t
+            cdr_des >> wchar_value >> wstring_value;
+            cdr_des.deserialize_array(wchar_array_2_value, 5).deserialize_array(wstring_array_2_value, 5);
+            cdr_des >> wchar_array_value >> wstring_array_value;
+            cdr_des >> wchar_vector_value >> wstring_vector_value;
+            cdr_des.deserialize_sequence(wchar_seq_value, wchar_seq_len).deserialize_sequence(wstring_seq_value,
+            wstring_seq_len);
+            cdr_des.deserialize(c_wstring_value);
+        });
 
     EXPECT_EQ(octet_value, octet_t);
     EXPECT_EQ(char_value, char_t);
@@ -6737,9 +6764,9 @@ TEST(CDRTests, ZeroSequenceAtTheEnd)
     Cdr cdr_ser_octet(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_octet << double_tt << octet_zero_sequence;
-    });
+        {
+            cdr_ser_octet << double_tt << octet_zero_sequence;
+        });
 
     // Deserialization.
     Cdr cdr_des_octet(cdrbuffer);
@@ -6747,174 +6774,174 @@ TEST(CDRTests, ZeroSequenceAtTheEnd)
     double value = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_octet >> value >> octet_zero_sequence;
-    });
+        {
+            cdr_des_octet >> value >> octet_zero_sequence;
+        });
 
     Cdr cdr_ser_char(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_char << double_tt << char_zero_sequence;
-    });
+        {
+            cdr_ser_char << double_tt << char_zero_sequence;
+        });
 
     // Deserialization.
     Cdr cdr_des_char(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_char >> value >> char_zero_sequence;
-    });
+        {
+            cdr_des_char >> value >> char_zero_sequence;
+        });
 
     Cdr cdr_ser_int8(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_int8 << double_tt << int8_zero_sequence;
-    });
+        {
+            cdr_ser_int8 << double_tt << int8_zero_sequence;
+        });
 
     // Deserialization.
     Cdr cdr_des_int8(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_int8 >> value >> int8_zero_sequence;
-    });
+        {
+            cdr_des_int8 >> value >> int8_zero_sequence;
+        });
 
     Cdr cdr_ser_ushort(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_ushort << double_tt << ushort_zero_sequence;
-    });
+        {
+            cdr_ser_ushort << double_tt << ushort_zero_sequence;
+        });
 
     // Deserialization.
     Cdr cdr_des_ushort(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_ushort >> value >> ushort_zero_sequence;
-    });
+        {
+            cdr_des_ushort >> value >> ushort_zero_sequence;
+        });
 
     Cdr cdr_ser_short(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_short << double_tt << short_zero_sequence;
-    });
+        {
+            cdr_ser_short << double_tt << short_zero_sequence;
+        });
 
     // Deserialization.
     Cdr cdr_des_short(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_short >> value >> short_zero_sequence;
-    });
+        {
+            cdr_des_short >> value >> short_zero_sequence;
+        });
 
     Cdr cdr_ser_ulong(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_ulong << double_tt << ulong_zero_sequence;
-    });
+        {
+            cdr_ser_ulong << double_tt << ulong_zero_sequence;
+        });
 
     // Deserialization.
     Cdr cdr_des_ulong(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_ulong >> value >> ulong_zero_sequence;
-    });
+        {
+            cdr_des_ulong >> value >> ulong_zero_sequence;
+        });
 
     Cdr cdr_ser_long(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_long << double_tt << long_zero_sequence;
-    });
+        {
+            cdr_ser_long << double_tt << long_zero_sequence;
+        });
 
     // Deserialization.
     Cdr cdr_des_long(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_long >> value >> long_zero_sequence;
-    });
+        {
+            cdr_des_long >> value >> long_zero_sequence;
+        });
 
     Cdr cdr_ser_ulonglong(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_ulonglong << double_tt << ulonglong_zero_sequence;
-    });
+        {
+            cdr_ser_ulonglong << double_tt << ulonglong_zero_sequence;
+        });
 
     // Deserialization.
     Cdr cdr_des_ulonglong(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_ulonglong >> value >> ulonglong_zero_sequence;
-    });
+        {
+            cdr_des_ulonglong >> value >> ulonglong_zero_sequence;
+        });
 
     Cdr cdr_ser_float(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_float << double_tt << float_zero_sequence;
-    });
+        {
+            cdr_ser_float << double_tt << float_zero_sequence;
+        });
 
     // Deserialization.
     Cdr cdr_des_float(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_float >> value >> float_zero_sequence;
-    });
+        {
+            cdr_des_float >> value >> float_zero_sequence;
+        });
 
     Cdr cdr_ser_double(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_double << double_tt << double_zero_sequence;
-    });
+        {
+            cdr_ser_double << double_tt << double_zero_sequence;
+        });
 
     // Deserialization.
     Cdr cdr_des_double(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_double >> value >> double_zero_sequence;
-    });
+        {
+            cdr_des_double >> value >> double_zero_sequence;
+        });
 
     Cdr cdr_ser_longdouble(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_longdouble << double_tt << longdouble_zero_sequence;
-    });
+        {
+            cdr_ser_longdouble << double_tt << longdouble_zero_sequence;
+        });
 
     // Deserialization.
     Cdr cdr_des_longdouble(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_longdouble >> value >> longdouble_zero_sequence;
-    });
+        {
+            cdr_des_longdouble >> value >> longdouble_zero_sequence;
+        });
 
     Cdr cdr_ser_bool(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_bool << double_tt << bool_zero_sequence;
-    });
+        {
+            cdr_ser_bool << double_tt << bool_zero_sequence;
+        });
 
     // Deserialization.
     Cdr cdr_des_bool(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_bool >> value >> bool_zero_sequence;
-    });
+        {
+            cdr_des_bool >> value >> bool_zero_sequence;
+        });
 }
 
 TEST(FastCDRTests, ZeroSequenceAtTheEnd)
@@ -6939,9 +6966,9 @@ TEST(FastCDRTests, ZeroSequenceAtTheEnd)
     FastCdr cdr_ser_octet(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_octet << double_tt << octet_zero_sequence;
-    });
+        {
+            cdr_ser_octet << double_tt << octet_zero_sequence;
+        });
 
     // Deserialization.
     FastCdr cdr_des_octet(cdrbuffer);
@@ -6949,174 +6976,174 @@ TEST(FastCDRTests, ZeroSequenceAtTheEnd)
     double value = 0;
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_octet >> value >> octet_zero_sequence;
-    });
+        {
+            cdr_des_octet >> value >> octet_zero_sequence;
+        });
 
     FastCdr cdr_ser_char(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_char << double_tt << char_zero_sequence;
-    });
+        {
+            cdr_ser_char << double_tt << char_zero_sequence;
+        });
 
     // Deserialization.
     FastCdr cdr_des_char(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_char >> value >> char_zero_sequence;
-    });
+        {
+            cdr_des_char >> value >> char_zero_sequence;
+        });
 
     FastCdr cdr_ser_int8(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_int8 << double_tt << int8_zero_sequence;
-    });
+        {
+            cdr_ser_int8 << double_tt << int8_zero_sequence;
+        });
 
     // Deserialization.
     FastCdr cdr_des_int8(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_int8 >> value >> int8_zero_sequence;
-    });
+        {
+            cdr_des_int8 >> value >> int8_zero_sequence;
+        });
 
     FastCdr cdr_ser_ushort(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_ushort << double_tt << ushort_zero_sequence;
-    });
+        {
+            cdr_ser_ushort << double_tt << ushort_zero_sequence;
+        });
 
     // Deserialization.
     FastCdr cdr_des_ushort(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_ushort >> value >> ushort_zero_sequence;
-    });
+        {
+            cdr_des_ushort >> value >> ushort_zero_sequence;
+        });
 
     FastCdr cdr_ser_short(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_short << double_tt << short_zero_sequence;
-    });
+        {
+            cdr_ser_short << double_tt << short_zero_sequence;
+        });
 
     // Deserialization.
     FastCdr cdr_des_short(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_short >> value >> short_zero_sequence;
-    });
+        {
+            cdr_des_short >> value >> short_zero_sequence;
+        });
 
     FastCdr cdr_ser_ulong(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_ulong << double_tt << ulong_zero_sequence;
-    });
+        {
+            cdr_ser_ulong << double_tt << ulong_zero_sequence;
+        });
 
     // Deserialization.
     FastCdr cdr_des_ulong(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_ulong >> value >> ulong_zero_sequence;
-    });
+        {
+            cdr_des_ulong >> value >> ulong_zero_sequence;
+        });
 
     FastCdr cdr_ser_long(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_long << double_tt << long_zero_sequence;
-    });
+        {
+            cdr_ser_long << double_tt << long_zero_sequence;
+        });
 
     // Deserialization.
     FastCdr cdr_des_long(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_long >> value >> long_zero_sequence;
-    });
+        {
+            cdr_des_long >> value >> long_zero_sequence;
+        });
 
     FastCdr cdr_ser_ulonglong(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_ulonglong << double_tt << ulonglong_zero_sequence;
-    });
+        {
+            cdr_ser_ulonglong << double_tt << ulonglong_zero_sequence;
+        });
 
     // Deserialization.
     FastCdr cdr_des_ulonglong(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_ulonglong >> value >> ulonglong_zero_sequence;
-    });
+        {
+            cdr_des_ulonglong >> value >> ulonglong_zero_sequence;
+        });
 
     FastCdr cdr_ser_float(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_float << double_tt << float_zero_sequence;
-    });
+        {
+            cdr_ser_float << double_tt << float_zero_sequence;
+        });
 
     // Deserialization.
     FastCdr cdr_des_float(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_float >> value >> float_zero_sequence;
-    });
+        {
+            cdr_des_float >> value >> float_zero_sequence;
+        });
 
     FastCdr cdr_ser_double(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_double << double_tt << double_zero_sequence;
-    });
+        {
+            cdr_ser_double << double_tt << double_zero_sequence;
+        });
 
     // Deserialization.
     FastCdr cdr_des_double(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_double >> value >> double_zero_sequence;
-    });
+        {
+            cdr_des_double >> value >> double_zero_sequence;
+        });
 
     FastCdr cdr_ser_longdouble(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_longdouble << double_tt << longdouble_zero_sequence;
-    });
+        {
+            cdr_ser_longdouble << double_tt << longdouble_zero_sequence;
+        });
 
     // Deserialization.
     FastCdr cdr_des_longdouble(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_longdouble >> value >> longdouble_zero_sequence;
-    });
+        {
+            cdr_des_longdouble >> value >> longdouble_zero_sequence;
+        });
 
     FastCdr cdr_ser_bool(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_ser_bool << double_tt << bool_zero_sequence;
-    });
+        {
+            cdr_ser_bool << double_tt << bool_zero_sequence;
+        });
 
     // Deserialization.
     FastCdr cdr_des_bool(cdrbuffer);
 
     EXPECT_NO_THROW(
-    {
-        cdr_des_bool >> value >> bool_zero_sequence;
-    });
+        {
+            cdr_des_bool >> value >> bool_zero_sequence;
+        });
 }
 
 TEST(CDRTests, StringWithNullChars)
@@ -7128,9 +7155,9 @@ TEST(CDRTests, StringWithNullChars)
     Cdr cdr_ser(cdrbuffer);
 
     EXPECT_THROW(
-    {
-        cdr_ser << str;
-    },
+        {
+            cdr_ser << str;
+        },
         BadParamException);
 }
 
@@ -7143,9 +7170,9 @@ TEST(FastCDRTests, StringWithNullChars)
     FastCdr cdr_ser(cdrbuffer);
 
     EXPECT_THROW(
-    {
-        cdr_ser << str;
-    },
+        {
+            cdr_ser << str;
+        },
         BadParamException);
 }
 
@@ -7156,9 +7183,9 @@ TEST(CDRTests, EmptyStringSerializationSize)
     FastBuffer cdrbuffer(buffer, 256);
     Cdr cdr_ser(cdrbuffer);
     EXPECT_NO_THROW(
-    {
-        cdr_ser << str;
-    });
+        {
+            cdr_ser << str;
+        });
     EXPECT_EQ(cdr_ser.get_serialized_data_length(), 5u);
 }
 
@@ -7169,8 +7196,8 @@ TEST(FastCDRTests, EmptyStringSerializationSize)
     FastBuffer cdrbuffer(buffer, 256);
     FastCdr cdr_ser(cdrbuffer);
     EXPECT_NO_THROW(
-    {
-        cdr_ser << str;
-    });
+        {
+            cdr_ser << str;
+        });
     EXPECT_EQ(cdr_ser.get_serialized_data_length(), 5u);
 }

--- a/test/cdr/SimpleTest.cpp
+++ b/test/cdr/SimpleTest.cpp
@@ -212,27 +212,64 @@ static void EXPECT_ARRAY_LONG_DOUBLE_EQ(
 
 template<typename T>
 static void check_bad_length_deserialization(
-        const T& const_value)
+        const T& const_value,
+        bool requires_dheader)
 {
-    char buffer[sizeof(uint32_t) + 1];
-
-    // Serialize wrong length (4GB)
+    // XCDRv1
     {
-        FastBuffer buf(buffer, sizeof(buffer));
-        Cdr cdr(buf);
-        uint32_t bad_length = 0xFFFFFFFF;
+        char buffer[sizeof(uint32_t) + 1];
 
-        EXPECT_NO_THROW(cdr << bad_length);
+        // Serialize wrong length (4GB)
+        {
+            FastBuffer buf(buffer, sizeof(buffer));
+            Cdr cdr(buf, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::CdrVersion::XCDRv1);
+            uint32_t bad_length = 0xFFFFFFFF;
+
+            EXPECT_NO_THROW(cdr << bad_length);
+        }
+
+        // Deserializing should throw
+        {
+            FastBuffer buf(buffer, sizeof(buffer));
+            Cdr cdr(buf, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::CdrVersion::XCDRv1);
+            T value;
+
+            EXPECT_THROW(cdr >> value, NotEnoughMemoryException);
+            EXPECT_NE(value, const_value);
+        }
     }
 
-    // Deserializing should throw
+    // XCDRv2
     {
-        FastBuffer buf(buffer, sizeof(buffer));
-        Cdr cdr(buf);
-        T value;
+        char buffer[sizeof(uint32_t) + sizeof(uint32_t) + 1];
 
-        EXPECT_THROW(cdr >> value, NotEnoughMemoryException);
-        EXPECT_NE(value, const_value);
+        // Serialize wrong length (4GB)
+        {
+            uint32_t bad_length = 0xFFFFFFFF;
+            FastBuffer buf(buffer, sizeof(buffer));
+            Cdr cdr(buf, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::CdrVersion::XCDRv2);
+
+            if (requires_dheader)
+            {
+                auto dheader = cdr.allocate_xcdrv2_dheader();
+                EXPECT_NO_THROW(cdr << bad_length);
+                EXPECT_NO_THROW(cdr.set_xcdrv2_dheader(dheader));
+            }
+            else
+            {
+                EXPECT_NO_THROW(cdr << bad_length);
+            }
+        }
+
+        // Deserializing should throw
+        {
+            FastBuffer buf(buffer, sizeof(buffer));
+            Cdr cdr(buf, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::CdrVersion::XCDRv2);
+            T value;
+
+            EXPECT_THROW(cdr >> value, NotEnoughMemoryException);
+            EXPECT_NE(value, const_value);
+        }
     }
 }
 
@@ -619,14 +656,14 @@ TEST(CDRTests, String)
 {
     check_good_case(string_t);
     check_no_space(string_t, 1);
-    check_bad_length_deserialization(string_t);
+    check_bad_length_deserialization(string_t, false);
 }
 
 TEST(CDRTests, WString)
 {
     check_good_case(wstring_t);
     check_no_space(wstring_t, 1);
-    check_bad_length_deserialization(wstring_t);
+    check_bad_length_deserialization(wstring_t, true);
 }
 
 TEST(CDRTests, EmptyString)
@@ -837,112 +874,112 @@ TEST(CDRTests, STDVectorOctet)
 {
     check_good_case(octet_vector_t);
     check_no_space(octet_vector_t, 1);
-    check_bad_length_deserialization(octet_vector_t);
+    check_bad_length_deserialization(octet_vector_t, false);
 }
 
 TEST(CDRTests, STDVectorChar)
 {
     check_good_case(char_vector_t);
     check_no_space(char_vector_t, 1);
-    check_bad_length_deserialization(char_vector_t);
+    check_bad_length_deserialization(char_vector_t, false);
 }
 
 TEST(CDRTests, STDVectorWChar)
 {
     check_good_case(wchar_vector_t);
     check_no_space(wchar_vector_t, 1);
-    check_bad_length_deserialization(wchar_vector_t);
+    check_bad_length_deserialization(wchar_vector_t, false);
 }
 
 TEST(CDRTests, STDVectorInt8)
 {
     check_good_case(int8_vector_t);
     check_no_space(int8_vector_t, 1);
-    check_bad_length_deserialization(int8_vector_t);
+    check_bad_length_deserialization(int8_vector_t, false);
 }
 
 TEST(CDRTests, STDVectorUnsignedShort)
 {
     check_good_case(ushort_vector_t);
     check_no_space(ushort_vector_t, 1);
-    check_bad_length_deserialization(ushort_vector_t);
+    check_bad_length_deserialization(ushort_vector_t, false);
 }
 
 TEST(CDRTests, STDVectorShort)
 {
     check_good_case(short_vector_t);
     check_no_space(short_vector_t, 1);
-    check_bad_length_deserialization(short_vector_t);
+    check_bad_length_deserialization(short_vector_t, false);
 }
 
 TEST(CDRTests, STDVectorUnsignedLong)
 {
     check_good_case(ulong_vector_t);
     check_no_space(ulong_vector_t, 1);
-    check_bad_length_deserialization(ulong_vector_t);
+    check_bad_length_deserialization(ulong_vector_t, false);
 }
 
 TEST(CDRTests, STDVectorLong)
 {
     check_good_case(long_vector_t);
     check_no_space(long_vector_t, 1);
-    check_bad_length_deserialization(long_vector_t);
+    check_bad_length_deserialization(long_vector_t, false);
 }
 
 TEST(CDRTests, STDVectorUnsignedLongLong)
 {
     check_good_case(ulonglong_vector_t);
     check_no_space(ulonglong_vector_t, 1);
-    check_bad_length_deserialization(ulonglong_vector_t);
+    check_bad_length_deserialization(ulonglong_vector_t, false);
 }
 
 TEST(CDRTests, STDVectorLongLong)
 {
     check_good_case(longlong_vector_t);
     check_no_space(longlong_vector_t, 1);
-    check_bad_length_deserialization(longlong_vector_t);
+    check_bad_length_deserialization(longlong_vector_t, false);
 }
 
 TEST(CDRTests, STDVectorFloat)
 {
     check_good_case(float_vector_t);
     check_no_space(float_vector_t, 1);
-    check_bad_length_deserialization(float_vector_t);
+    check_bad_length_deserialization(float_vector_t, false);
 }
 
 TEST(CDRTests, STDVectorDouble)
 {
     check_good_case(double_vector_t);
     check_no_space(double_vector_t, 1);
-    check_bad_length_deserialization(double_vector_t);
+    check_bad_length_deserialization(double_vector_t, false);
 }
 
 TEST(CDRTests, STDVectorLongDouble)
 {
     check_good_case(ldouble_vector_t);
     check_no_space(ldouble_vector_t, 1);
-    check_bad_length_deserialization(ldouble_vector_t);
+    check_bad_length_deserialization(ldouble_vector_t, false);
 }
 
 TEST(CDRTests, STDVectorBoolean)
 {
     check_good_case(bool_vector_t);
     check_no_space(bool_vector_t, 1);
-    check_bad_length_deserialization(bool_vector_t);
+    check_bad_length_deserialization(bool_vector_t, false);
 }
 
 TEST(CDRTests, STDVectorString)
 {
     check_good_case(string_vector_t);
     check_no_space(string_vector_t, 1);
-    check_bad_length_deserialization(string_vector_t);
+    check_bad_length_deserialization(string_vector_t, true);
 }
 
 TEST(CDRTests, STDVectorWString)
 {
     check_good_case(wstring_vector_t);
     check_no_space(wstring_vector_t, 1);
-    check_bad_length_deserialization(wstring_vector_t);
+    check_bad_length_deserialization(wstring_vector_t, true);
 }
 
 TEST(CDRTests, STDTripleArrayUnsignedLong)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This improves the `check_bad_length_deserialization` tests to include a DHEADER when required, adds a missing check on sequence length, and adds checks when deserializing a DHEADER.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.3.x 2.2.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-CDR/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: CI pass and failing tests are unrelated with the changes.
